### PR TITLE
feat: add opt-in request lifecycle logging

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,10 +1,7 @@
 name: Auto merge Dependabot updates
 
 on:
-  check_suite:
-    types:
-      - completed
-  pull_request:
+  pull_request_target:
     types:
       - labeled
       - unlabeled
@@ -15,8 +12,15 @@ on:
       - reopened
       - unlocked
 
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+  statuses: read
+
 jobs:
   auto-merge:
+    if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: auto-merge

--- a/README.md
+++ b/README.md
@@ -7,21 +7,200 @@
 [![npm version](https://img.shields.io/npm/v/trembita/latest.svg)](https://www.npmjs.com/package/trembita)
 [![API docs](https://img.shields.io/badge/docs-GitHub%20Pages-24292e)](https://oleg-koval.github.io/trembita/)
 
-Small **TypeScript** helper for calling third-party **HTTP JSON** APIs:
-**`fetch`**, strict **`Result`** types, **no** legacy `request` / Bluebird
-stack.
+Lightweight **TypeScript HTTP client** for consuming third-party **JSON APIs**.
+Built on the platform **`fetch`** API with strict **`Result<T, E>`** error
+handling — zero legacy dependencies, no `request`, no Bluebird.
+
+## Why trembita
+
+- **Type-safe errors** — every failure is a tagged discriminated union
+  (`error.kind`), not a thrown exception. TypeScript narrows the error for you.
+- **Zero runtime dependencies** — uses `fetch` and `URL` from the platform.
+  Works in Node >= 20 and browsers (via bundler).
+- **Tiny API surface** — `createTrembita()` → `{ request, client }`. No classes,
+  no middleware chains, no plugin system.
+- **Testable by design** — inject `fetchImpl` to swap `fetch` in unit tests
+  without mocking globals.
+- **ESM-only, strict TypeScript** — ships `.d.ts` + source maps, tree-shakeable
+  with `sideEffects: false`.
+
+## Use cases
+
+### Consuming a REST API in a backend service
+
+When your Node service calls a third-party REST API (payment provider, CRM,
+shipping tracker), trembita gives you a typed client with predictable error
+handling instead of scattered `try/catch` blocks around raw `fetch`.
+
+```typescript
+import { createTrembita, HTTP_OK } from 'trembita';
+
+const stripe = createTrembita({
+  endpoint: 'https://api.stripe.com/v1'
+});
+if (!stripe.ok) throw new Error('Bad Stripe config');
+
+const charges = await stripe.value.request({
+  path: '/charges',
+  query: { limit: '10' },
+  headers: { Authorization: `Bearer ${process.env.STRIPE_KEY}` },
+  expectedCodes: [HTTP_OK]
+});
+
+if (!charges.ok) {
+  if (charges.error.kind === 'unexpected_status') {
+    console.error('Stripe returned', charges.error.statusCode);
+  }
+}
+```
+
+### Wrapping a microservice-to-microservice call
+
+Internal services often communicate over HTTP JSON. trembita standardizes how
+you send requests and handle non-200 responses across service boundaries.
+
+```typescript
+const userService = createTrembita({
+  endpoint: 'http://user-service.internal:3000'
+});
+if (!userService.ok) throw new Error('Bad user-service config');
+
+const user = await userService.value.request({
+  path: `/users/${userId}`,
+  expectedCodes: [HTTP_OK]
+});
+
+if (!user.ok && user.error.kind === 'unexpected_status') {
+  if (user.error.statusCode === 404) {
+    return null;
+  }
+}
+```
+
+### Health checks and monitoring
+
+Use the lower-level `client` function when you need the raw status code and body
+— useful for health checks, readiness probes, or status dashboards.
+
+```typescript
+const raw = await api.value.client({ path: '/health' });
+if (raw.ok && raw.value.statusCode === 200) {
+  console.log('Service healthy:', raw.value.body);
+}
+```
+
+### Browser fetch with a bundler
+
+trembita works in the browser with any bundler (Vite, webpack, esbuild). The
+same ESM entry point uses the global `fetch` and `URL` APIs.
+
+```typescript
+import { createTrembita, HTTP_OK } from 'trembita';
+
+const api = createTrembita({
+  endpoint: 'https://api.example.com/v1'
+});
+if (!api.ok) {
+  showError('Failed to initialize API client');
+}
+```
+
+### Testing with injected fetch
+
+Pass a mock `fetchImpl` to test your integration layer without touching the
+network or patching globals.
+
+```typescript
+import { createTrembita, HTTP_OK } from 'trembita';
+import { vi } from 'vitest';
+
+const fetchImpl = vi.fn(() =>
+  Promise.resolve(new Response(JSON.stringify({ id: 1 }), { status: 200 }))
+);
+
+const created = createTrembita({
+  endpoint: 'https://api.test.com',
+  fetchImpl
+});
+
+const result = await created.value.request({
+  path: '/items/1',
+  expectedCodes: [HTTP_OK]
+});
+
+expect(result.ok).toBe(true);
+expect(fetchImpl).toHaveBeenCalledOnce();
+```
 
 ## Functional style
 
 The API is **functional-first**: `createTrembita` returns a **`Result`**, then
-plain **`client` / `request`** functions—no class instance. Expected failures
-use **tagged errors** (`error.kind`) so callers narrow with types instead of
-relying on **`try/catch`** for normal HTTP outcomes. Where it stays honest
-without I/O, helpers use **`Result`** too (options, URLs, JSON parsing).
+plain **`client` / `request`** functions — no class instance. Failures use
+**tagged errors** (`error.kind`) so callers narrow with types instead of relying
+on **`try/catch`** for normal HTTP outcomes.
 
 This is **not** pure FP end-to-end: **`fetch`**, the network, and logging are
 ordinary side effects. Think **FP-style errors and surface area**, not a fully
 pure program.
+
+## Error handling
+
+Every operation returns a `Result<T, E>` — either `{ ok: true, value }` or
+`{ ok: false, error }`. Errors are tagged unions you can narrow with
+`error.kind`:
+
+| `error.kind`              | When                                           |
+| ------------------------- | ---------------------------------------------- |
+| `missing_options`         | No options passed to `createTrembita`          |
+| `options_not_object`      | Options is not an object                       |
+| `missing_endpoint`        | `endpoint` field is missing                    |
+| `endpoint_not_string`     | `endpoint` is not a string                     |
+| `endpoint_invalid_url`    | `endpoint` URL cannot be parsed or bad scheme  |
+| `invalid_request_options` | Missing or invalid `path`/`url` in request     |
+| `fetch_failed`            | Network error (DNS, timeout, connection reset) |
+| `invalid_json`            | Response body is not valid JSON                |
+| `unexpected_status`       | HTTP status not in `expectedCodes`             |
+
+## API reference
+
+Full TypeDoc documentation is published at
+[oleg-koval.github.io/trembita](https://oleg-koval.github.io/trembita/).
+
+### `createTrembita(options)`
+
+Creates a client bound to a base URL.
+
+| Option      | Type                | Default            | Description                  |
+| ----------- | ------------------- | ------------------ | ---------------------------- |
+| `endpoint`  | `string` (required) | —                  | Base URL for all requests    |
+| `fetchImpl` | `typeof fetch`      | `globalThis.fetch` | Custom fetch for testing     |
+| `log`       | `Logger`            | `console`          | Logger with `trace`..`error` |
+
+Returns `Result<TrembitaClient, TrembitaInitError>`.
+
+### `request(options)`
+
+Sends a request and returns the parsed JSON body if the status matches
+`expectedCodes` (default: `[200, 201]`).
+
+Returns `Promise<Result<unknown, TrembitaRequestError>>`.
+
+### `client(options)`
+
+Sends a request and returns `{ statusCode, body, path }` regardless of status.
+
+Returns `Promise<Result<TrembitaHttpResponse, TrembitaSendError>>`.
+
+### Request options
+
+| Option          | Type                          | Default                  |
+| --------------- | ----------------------------- | ------------------------ |
+| `path` or `url` | `string`                      | — (required)             |
+| `method`        | `string`                      | `GET` / `POST` with body |
+| `headers`       | `Record<string, string>`      | `{}`                     |
+| `query` or `qs` | `Record<string, string\|...>` | —                        |
+| `body`          | `unknown`                     | —                        |
+| `expectedCodes` | `number[]`                    | `[200, 201]`             |
 
 ## Requirements
 
@@ -34,44 +213,6 @@ pure program.
 npm install trembita
 ```
 
-## Usage
-
-```typescript
-import { createTrembita, HTTP_OK } from 'trembita';
-
-const created = createTrembita({
-  endpoint: 'https://api.example.com/v1'
-});
-
-if (!created.ok) {
-  console.error(created.error);
-  process.exit(1);
-}
-
-const { request, client } = created.value;
-
-const users = await request({
-  path: '/users',
-  query: { page: '2' },
-  expectedCodes: [HTTP_OK]
-});
-
-if (!users.ok) {
-  if (users.error.kind === 'unexpected_status') {
-    console.error(users.error.statusCode, users.error.body);
-  }
-  process.exit(1);
-}
-
-console.log(users.value);
-
-// Lower level: status + parsed JSON body
-const raw = await client({ url: '/health' });
-if (raw.ok) {
-  console.log(raw.value.statusCode, raw.value.body);
-}
-```
-
 ## Migration from v1.x
 
 This version line is a **breaking v2 migration** to the functional `Result` API.
@@ -82,10 +223,6 @@ This version line is a **breaking v2 migration** to the functional `Result` API.
 | `this.request({ url, qs, expectedCodes })` throwing    | `request({ path or url, query or qs, expectedCodes })` → **`Promise<Result<unknown, TrembitaRequestError>>`**           |
 | `catch (UnexpectedStatusCodeError)`                    | Narrow **`!result.ok`** and check **`result.error.kind === 'unexpected_status'`** (prefer **`kind`**, not message text) |
 | `request` / `bluebird` / `validator`                   | **`fetch`**, **`URL`**, optional **`fetchImpl`** for tests                                                              |
-
-See **`SPEC.md`** and **`CHANGELOG.md`** for design notes and release semantics
-(**semantic-release** +
-[semantic-release-npm-github-publish](https://oleg-koval.github.io/semantic-release-npm-github-publish/)).
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -184,9 +184,12 @@ Returns `Result<TrembitaClient, TrembitaInitError>`.
 - When `log` is provided, trembita emits lifecycle events:
   - `request:start` (debug): endpoint, path, method, sanitized headers
   - `request:success` (info): endpoint, path, statusCode, durationMs
-  - `request:unexpected_status` (warn): endpoint, path, statusCode, expectedCodes
-  - `request:fetch_failed` / `request:invalid_json` (error): endpoint, path, error kind
-- Sensitive request headers are redacted in logs (`authorization`, `cookie`, `set-cookie`, `x-api-key`, `proxy-authorization`).
+  - `request:unexpected_status` (warn): endpoint, path, statusCode,
+    expectedCodes
+  - `request:fetch_failed` / `request:invalid_json` (error): endpoint, path,
+    error kind
+- Sensitive request headers are redacted in logs (`authorization`, `cookie`,
+  `set-cookie`, `x-api-key`, `proxy-authorization`).
 
 ### `request(options)`
 

--- a/README.md
+++ b/README.md
@@ -174,9 +174,19 @@ Creates a client bound to a base URL.
 | ----------- | ------------------- | ------------------ | ---------------------------- |
 | `endpoint`  | `string` (required) | —                  | Base URL for all requests    |
 | `fetchImpl` | `typeof fetch`      | `globalThis.fetch` | Custom fetch for testing     |
-| `log`       | `Logger`            | `console`          | Logger with `trace`..`error` |
+| `log`       | `Logger`            | no-op logger       | Logger with `trace`..`error` |
 
 Returns `Result<TrembitaClient, TrembitaInitError>`.
+
+### Logging contract
+
+- Logging is opt-in: no logger means no internal logs.
+- When `log` is provided, trembita emits lifecycle events:
+  - `request:start` (debug): endpoint, path, method, sanitized headers
+  - `request:success` (info): endpoint, path, statusCode, durationMs
+  - `request:unexpected_status` (warn): endpoint, path, statusCode, expectedCodes
+  - `request:fetch_failed` / `request:invalid_json` (error): endpoint, path, error kind
+- Sensitive request headers are redacted in logs (`authorization`, `cookie`, `set-cookie`, `x-api-key`, `proxy-authorization`).
 
 ### `request(options)`
 

--- a/src/trembita.ts
+++ b/src/trembita.ts
@@ -215,11 +215,7 @@ export const createTrembita = (
   if (!validated.ok) {
     return validated;
   }
-  const {
-    endpoint,
-    fetchImpl = globalThis.fetch,
-    log = {}
-  } = validated.value;
+  const { endpoint, fetchImpl = globalThis.fetch, log = {} } = validated.value;
   const send = makeSend(endpoint, fetchImpl, log);
   const request = makeRequest(endpoint, send, log);
   return ok({

--- a/src/trembita.ts
+++ b/src/trembita.ts
@@ -40,6 +40,42 @@ export type TrembitaClient = Readonly<{
   ) => Promise<Result<unknown, TrembitaRequestError>>;
 }>;
 
+const SENSITIVE_HEADER_NAMES = new Set([
+  'authorization',
+  'cookie',
+  'set-cookie',
+  'x-api-key',
+  'proxy-authorization'
+]);
+
+const REDACTED_HEADER_VALUE = '[REDACTED]';
+
+const sanitizeHeaders = (
+  headers: HeadersInit | undefined
+): Readonly<Record<string, string>> => {
+  const sanitized: Record<string, string> = {};
+  const normalizedHeaders = new Headers(headers);
+  normalizedHeaders.forEach((value, key) => {
+    sanitized[key] = SENSITIVE_HEADER_NAMES.has(key)
+      ? REDACTED_HEADER_VALUE
+      : value;
+  });
+  return sanitized;
+};
+
+const callLog = (
+  logger: Logger,
+  level: keyof Logger,
+  event: string,
+  details: Readonly<Record<string, unknown>>
+): void => {
+  const fn = logger[level];
+  if (typeof fn !== 'function') {
+    return;
+  }
+  fn(event, details);
+};
+
 const resolvePath = (
   options: TrembitaFetchOptions
 ): Result<string, TrembitaSendError> => {
@@ -87,7 +123,7 @@ const parseJsonBody = (text: string): Result<unknown, TrembitaSendError> => {
 };
 
 const makeSend =
-  (endpoint: string, fetchImpl: typeof fetch) =>
+  (endpoint: string, fetchImpl: typeof fetch, log: Logger) =>
   async (
     options: TrembitaFetchOptions
   ): Promise<Result<TrembitaHttpResponse, TrembitaSendError>> => {
@@ -101,25 +137,51 @@ const makeSend =
       fullUrl = appendQuery(fullUrl, query);
     }
     const init = buildRequestInit(options);
+    const startedAtMs = Date.now();
+    callLog(log, 'debug', 'request:start', {
+      endpoint,
+      path: pathResult.value,
+      method: init.method ?? 'GET',
+      headers: sanitizeHeaders(init.headers)
+    });
     try {
       const response = await fetchImpl(fullUrl, init);
       const text = await response.text();
       const bodyResult = parseJsonBody(text);
       if (!bodyResult.ok) {
+        callLog(log, 'error', 'request:invalid_json', {
+          endpoint,
+          path: pathResult.value,
+          statusCode: response.status,
+          durationMs: Date.now() - startedAtMs,
+          errorKind: bodyResult.error.kind
+        });
         return bodyResult;
       }
+      callLog(log, 'info', 'request:success', {
+        endpoint,
+        path: pathResult.value,
+        statusCode: response.status,
+        durationMs: Date.now() - startedAtMs
+      });
       return ok({
         statusCode: response.status,
         body: bodyResult.value,
         path: pathResult.value
       });
     } catch (cause) {
+      callLog(log, 'error', 'request:fetch_failed', {
+        endpoint,
+        path: pathResult.value,
+        durationMs: Date.now() - startedAtMs,
+        errorKind: 'fetch_failed'
+      });
       return err({ kind: 'fetch_failed', cause });
     }
   };
 
 const makeRequest =
-  (endpoint: string, send: ReturnType<typeof makeSend>) =>
+  (endpoint: string, send: ReturnType<typeof makeSend>, log: Logger) =>
   async (
     options: TrembitaFetchOptions
   ): Promise<Result<unknown, TrembitaRequestError>> => {
@@ -130,6 +192,12 @@ const makeRequest =
     const expectedCodes = options.expectedCodes ?? DEFAULT_EXPECTED_CODES;
     const { statusCode, body, path } = sent.value;
     if (!expectedCodes.includes(statusCode)) {
+      callLog(log, 'warn', 'request:unexpected_status', {
+        endpoint,
+        path,
+        statusCode,
+        expectedCodes
+      });
       return err({
         kind: 'unexpected_status',
         statusCode,
@@ -150,10 +218,10 @@ export const createTrembita = (
   const {
     endpoint,
     fetchImpl = globalThis.fetch,
-    log = console
+    log = {}
   } = validated.value;
-  const send = makeSend(endpoint, fetchImpl);
-  const request = makeRequest(endpoint, send);
+  const send = makeSend(endpoint, fetchImpl, log);
+  const request = makeRequest(endpoint, send, log);
   return ok({
     endpoint,
     log,

--- a/test/trembita.test.ts
+++ b/test/trembita.test.ts
@@ -162,15 +162,24 @@ describe('createTrembita', () => {
   });
 
   it('does not write to console when logger not provided', async () => {
-    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const infoSpy = vi
+      .spyOn(console, 'info')
+      .mockImplementation(() => undefined);
+    const warnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
     const errorSpy = vi
       .spyOn(console, 'error')
       .mockImplementation(() => undefined);
     const fetchImpl = vi.fn(() =>
-      Promise.resolve(new Response(JSON.stringify(expectedBody), { status: HTTP_OK }))
+      Promise.resolve(
+        new Response(JSON.stringify(expectedBody), { status: HTTP_OK })
+      )
     );
-    const created = createTrembita({ endpoint: 'https://example.com/api', fetchImpl });
+    const created = createTrembita({
+      endpoint: 'https://example.com/api',
+      fetchImpl
+    });
     expect(created.ok).toBe(true);
     if (!created.ok) {
       return;
@@ -194,7 +203,9 @@ describe('createTrembita', () => {
       error: vi.fn()
     };
     const fetchImpl = vi.fn(() =>
-      Promise.resolve(new Response(JSON.stringify(expectedBody), { status: HTTP_OK }))
+      Promise.resolve(
+        new Response(JSON.stringify(expectedBody), { status: HTTP_OK })
+      )
     );
     const created = createTrembita({
       endpoint: 'https://example.com/api',
@@ -230,7 +241,9 @@ describe('createTrembita', () => {
       debug: vi.fn()
     };
     const fetchImpl = vi.fn(() =>
-      Promise.resolve(new Response(JSON.stringify(expectedBody), { status: HTTP_OK }))
+      Promise.resolve(
+        new Response(JSON.stringify(expectedBody), { status: HTTP_OK })
+      )
     );
     const created = createTrembita({
       endpoint: 'https://example.com/api',

--- a/test/trembita.test.ts
+++ b/test/trembita.test.ts
@@ -158,7 +158,168 @@ describe('createTrembita', () => {
     if (!created.ok) {
       return;
     }
-    expect(created.value.log).toBe(console);
+    expect(created.value.log).toEqual({});
+  });
+
+  it('does not write to console when logger not provided', async () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const errorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(new Response(JSON.stringify(expectedBody), { status: HTTP_OK }))
+    );
+    const created = createTrembita({ endpoint: 'https://example.com/api', fetchImpl });
+    expect(created.ok).toBe(true);
+    if (!created.ok) {
+      return;
+    }
+
+    const res = await created.value.request({ path: '/users' });
+    expect(res.ok).toBe(true);
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+    infoSpy.mockRestore();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('emits lifecycle logs when logger provided', async () => {
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    };
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(new Response(JSON.stringify(expectedBody), { status: HTTP_OK }))
+    );
+    const created = createTrembita({
+      endpoint: 'https://example.com/api',
+      fetchImpl,
+      log: logger
+    });
+    expect(created.ok).toBe(true);
+    if (!created.ok) {
+      return;
+    }
+    const res = await created.value.request({ path: '/users' });
+    expect(res.ok).toBe(true);
+    expect(logger.debug).toHaveBeenCalledWith(
+      'request:start',
+      expect.objectContaining({
+        endpoint: 'https://example.com/api',
+        path: '/users',
+        method: 'GET'
+      })
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      'request:success',
+      expect.objectContaining({
+        endpoint: 'https://example.com/api',
+        path: '/users',
+        statusCode: HTTP_OK
+      })
+    );
+  });
+
+  it('redacts sensitive headers in request:start logs', async () => {
+    const logger = {
+      debug: vi.fn()
+    };
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(new Response(JSON.stringify(expectedBody), { status: HTTP_OK }))
+    );
+    const created = createTrembita({
+      endpoint: 'https://example.com/api',
+      fetchImpl,
+      log: logger
+    });
+    expect(created.ok).toBe(true);
+    if (!created.ok) {
+      return;
+    }
+    const res = await created.value.request({
+      path: '/users',
+      headers: {
+        Authorization: 'Bearer super-secret',
+        Cookie: 'session=abc',
+        'X-Api-Key': 'token',
+        'X-Request-Id': 'req-1'
+      }
+    });
+    expect(res.ok).toBe(true);
+    expect(logger.debug).toHaveBeenCalledWith(
+      'request:start',
+      expect.objectContaining({
+        headers: {
+          authorization: '[REDACTED]',
+          cookie: '[REDACTED]',
+          'x-api-key': '[REDACTED]',
+          'x-request-id': 'req-1'
+        }
+      })
+    );
+  });
+
+  it('emits warning on unexpected status', async () => {
+    const logger = {
+      warn: vi.fn()
+    };
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(new Response(undefined, { status: 404 }))
+    );
+    const created = createTrembita({
+      endpoint: 'https://example.com/api',
+      fetchImpl,
+      log: logger
+    });
+    expect(created.ok).toBe(true);
+    if (!created.ok) {
+      return;
+    }
+    const res = await created.value.request({
+      path: '/missing',
+      expectedCodes: [HTTP_OK]
+    });
+    expect(res.ok).toBe(false);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'request:unexpected_status',
+      expect.objectContaining({
+        endpoint: 'https://example.com/api',
+        path: '/missing',
+        statusCode: 404,
+        expectedCodes: [HTTP_OK]
+      })
+    );
+  });
+
+  it('emits error on fetch failure', async () => {
+    const logger = {
+      error: vi.fn()
+    };
+    const fetchImpl = vi.fn(() => Promise.reject(new Error('network')));
+    const created = createTrembita({
+      endpoint: 'https://example.com/api',
+      fetchImpl,
+      log: logger
+    });
+    expect(created.ok).toBe(true);
+    if (!created.ok) {
+      return;
+    }
+    const res = await created.value.request({ path: '/fail' });
+    expect(res.ok).toBe(false);
+    expect(logger.error).toHaveBeenCalledWith(
+      'request:fetch_failed',
+      expect.objectContaining({
+        endpoint: 'https://example.com/api',
+        path: '/fail',
+        errorKind: 'fetch_failed'
+      })
+    );
   });
 
   it('client returns status and body', async () => {


### PR DESCRIPTION
## Summary
- add opt-in lifecycle logging events in request/send pipeline
- remove implicit console default and keep logging silent unless logger injected
- redact sensitive headers in request logs and document logging contract

## Test plan
- [x] npm run test
- [x] npm run lint:fix
- [x] npm run build