### PR TITLE
feat: add timeout handling and optional circuit breaker

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,13 +172,13 @@ Full TypeDoc documentation is published at
 
 Creates a client bound to a base URL.
 
-| Option      | Type                | Default            | Description               |
-| ----------- | ------------------- | ------------------ | ------------------------- |
-| `endpoint`  | `string` (required) | —                  | Base URL for all requests |
-| `fetchImpl` | `typeof fetch`      | `globalThis.fetch` | Custom fetch for testing  |
-| `log`       | `Logger`            | `console`          | Logger with `trace`..`error` |
-| `timeoutMs` | `number`            | —                  | Default timeout for requests |
-| `circuitBreaker` | `{ failureThreshold: number; cooldownMs: number }` | — | Optional consecutive-failure breaker |
+| Option           | Type                                               | Default            | Description                          |
+| ---------------- | -------------------------------------------------- | ------------------ | ------------------------------------ |
+| `endpoint`       | `string` (required)                                | —                  | Base URL for all requests            |
+| `fetchImpl`      | `typeof fetch`                                     | `globalThis.fetch` | Custom fetch for testing             |
+| `log`            | `Logger`                                           | `console`          | Logger with `trace`..`error`         |
+| `timeoutMs`      | `number`                                           | —                  | Default timeout for requests         |
+| `circuitBreaker` | `{ failureThreshold: number; cooldownMs: number }` | —                  | Optional consecutive-failure breaker |
 
 Returns `Result<TrembitaClient, TrembitaInitError>`.
 

--- a/README.md
+++ b/README.md
@@ -149,17 +149,19 @@ Every operation returns a `Result<T, E>` — either `{ ok: true, value }` or
 `{ ok: false, error }`. Errors are tagged unions you can narrow with
 `error.kind`:
 
-| `error.kind`              | When                                           |
-| ------------------------- | ---------------------------------------------- |
-| `missing_options`         | No options passed to `createTrembita`          |
-| `options_not_object`      | Options is not an object                       |
-| `missing_endpoint`        | `endpoint` field is missing                    |
-| `endpoint_not_string`     | `endpoint` is not a string                     |
-| `endpoint_invalid_url`    | `endpoint` URL cannot be parsed or bad scheme  |
-| `invalid_request_options` | Missing or invalid `path`/`url` in request     |
-| `fetch_failed`            | Network error (DNS, timeout, connection reset) |
-| `invalid_json`            | Response body is not valid JSON                |
-| `unexpected_status`       | HTTP status not in `expectedCodes`             |
+| `error.kind`              | When                                             |
+| ------------------------- | ------------------------------------------------ |
+| `missing_options`         | No options passed to `createTrembita`            |
+| `options_not_object`      | Options is not an object                         |
+| `missing_endpoint`        | `endpoint` field is missing                      |
+| `endpoint_not_string`     | `endpoint` is not a string                       |
+| `endpoint_invalid_url`    | `endpoint` URL cannot be parsed or bad scheme    |
+| `invalid_request_options` | Missing or invalid `path`/`url` in request       |
+| `fetch_failed`            | Network error (DNS, timeout, connection reset)   |
+| `timeout`                 | Request exceeded configured timeout              |
+| `circuit_open`            | Circuit breaker is open; request short-circuited |
+| `invalid_json`            | Response body is not valid JSON                  |
+| `unexpected_status`       | HTTP status not in `expectedCodes`               |
 
 ## API reference
 
@@ -170,11 +172,13 @@ Full TypeDoc documentation is published at
 
 Creates a client bound to a base URL.
 
-| Option      | Type                | Default            | Description                  |
-| ----------- | ------------------- | ------------------ | ---------------------------- |
-| `endpoint`  | `string` (required) | —                  | Base URL for all requests    |
-| `fetchImpl` | `typeof fetch`      | `globalThis.fetch` | Custom fetch for testing     |
+| Option      | Type                | Default            | Description               |
+| ----------- | ------------------- | ------------------ | ------------------------- |
+| `endpoint`  | `string` (required) | —                  | Base URL for all requests |
+| `fetchImpl` | `typeof fetch`      | `globalThis.fetch` | Custom fetch for testing  |
 | `log`       | `Logger`            | `console`          | Logger with `trace`..`error` |
+| `timeoutMs` | `number`            | —                  | Default timeout for requests |
+| `circuitBreaker` | `{ failureThreshold: number; cooldownMs: number }` | — | Optional consecutive-failure breaker |
 
 Returns `Result<TrembitaClient, TrembitaInitError>`.
 
@@ -201,6 +205,8 @@ Returns `Promise<Result<TrembitaHttpResponse, TrembitaSendError>>`.
 | `query` or `qs` | `Record<string, string\|...>` | —                        |
 | `body`          | `unknown`                     | —                        |
 | `expectedCodes` | `number[]`                    | `[200, 201]`             |
+| `timeoutMs`     | `number`                      | init `timeoutMs`         |
+| `signal`        | `AbortSignal`                 | —                        |
 
 ## Requirements
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -7,6 +7,8 @@ export type TrembitaInitError =
 
 export type TrembitaSendError =
   | Readonly<{ kind: 'fetch_failed'; cause: unknown }>
+  | Readonly<{ kind: 'timeout'; timeoutMs: number }>
+  | Readonly<{ kind: 'circuit_open'; retryAfterMs: number }>
   | Readonly<{ kind: 'invalid_json'; cause: unknown }>
   | Readonly<{
       kind: 'invalid_request_options';

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export {
   validateInitOptions,
   isOptionsObject,
   type Logger,
+  type CircuitBreakerOptions,
   type TrembitaInitOptions
 } from './validate.js';
 export { HTTP_CREATED, HTTP_OK, DEFAULT_EXPECTED_CODES } from './constants.js';

--- a/src/trembita.ts
+++ b/src/trembita.ts
@@ -6,7 +6,7 @@ import type {
 } from './errors.js';
 import { err, ok, type Result } from './result.js';
 import { appendQuery, joinEndpointPath } from './url.js';
-import type { Logger } from './validate.js';
+import type { CircuitBreakerOptions, Logger } from './validate.js';
 import { validateInitOptions } from './validate.js';
 
 export type TrembitaHttpResponse = Readonly<{
@@ -27,6 +27,8 @@ export type TrembitaFetchOptions = Readonly<{
   qs?: Readonly<Record<string, string | number | boolean | null | undefined>>;
   body?: unknown;
   expectedCodes?: readonly number[];
+  timeoutMs?: number;
+  signal?: AbortSignal;
 }>;
 
 export type TrembitaClient = Readonly<{
@@ -75,6 +77,84 @@ const buildRequestInit = (options: TrembitaFetchOptions): RequestInit => {
   return { method, headers, body };
 };
 
+type BuiltSignal = Readonly<{
+  signal: AbortSignal | undefined;
+  didTimeout: () => boolean;
+  cleanup: () => void;
+}>;
+
+const buildSignal = (
+  options: TrembitaFetchOptions,
+  defaultTimeoutMs: number | undefined
+): BuiltSignal => {
+  const timeoutMs = options.timeoutMs ?? defaultTimeoutMs;
+  const controller = new AbortController();
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = false;
+
+  const onAbort = (): void => {
+    controller.abort();
+  };
+  options.signal?.addEventListener('abort', onAbort);
+  if (options.signal?.aborted) {
+    controller.abort();
+  }
+
+  if (timeoutMs !== undefined) {
+    timeoutHandle = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, timeoutMs);
+  }
+
+  const signal =
+    options.signal === undefined && timeoutMs === undefined
+      ? undefined
+      : controller.signal;
+
+  return {
+    signal,
+    didTimeout: () => timedOut,
+    cleanup: () => {
+      options.signal?.removeEventListener('abort', onAbort);
+      if (timeoutHandle !== undefined) {
+        clearTimeout(timeoutHandle);
+      }
+    }
+  };
+};
+
+type CircuitBreakerState = {
+  readonly options: CircuitBreakerOptions;
+  failures: number;
+  openedUntilMs: number | undefined;
+};
+
+const isCircuitOpen = (state: CircuitBreakerState): number | undefined => {
+  if (state.openedUntilMs === undefined) {
+    return undefined;
+  }
+  const remaining = state.openedUntilMs - Date.now();
+  if (remaining <= 0) {
+    state.openedUntilMs = undefined;
+    state.failures = 0;
+    return undefined;
+  }
+  return remaining;
+};
+
+const registerFailure = (state: CircuitBreakerState): void => {
+  state.failures += 1;
+  if (state.failures >= state.options.failureThreshold) {
+    state.openedUntilMs = Date.now() + state.options.cooldownMs;
+  }
+};
+
+const registerSuccess = (state: CircuitBreakerState): void => {
+  state.failures = 0;
+  state.openedUntilMs = undefined;
+};
+
 const parseJsonBody = (text: string): Result<unknown, TrembitaSendError> => {
   if (text.length === 0) {
     return ok(undefined);
@@ -87,7 +167,12 @@ const parseJsonBody = (text: string): Result<unknown, TrembitaSendError> => {
 };
 
 const makeSend =
-  (endpoint: string, fetchImpl: typeof fetch) =>
+  (
+    endpoint: string,
+    fetchImpl: typeof fetch,
+    defaultTimeoutMs: number | undefined,
+    circuitBreaker: CircuitBreakerState | undefined
+  ) =>
   async (
     options: TrembitaFetchOptions
   ): Promise<Result<TrembitaHttpResponse, TrembitaSendError>> => {
@@ -95,18 +180,35 @@ const makeSend =
     if (!pathResult.ok) {
       return pathResult;
     }
+    if (circuitBreaker !== undefined) {
+      const retryAfterMs = isCircuitOpen(circuitBreaker);
+      if (retryAfterMs !== undefined) {
+        return err({ kind: 'circuit_open', retryAfterMs });
+      }
+    }
     let fullUrl = joinEndpointPath(endpoint, pathResult.value);
     const query = resolveQuery(options);
     if (query) {
       fullUrl = appendQuery(fullUrl, query);
     }
     const init = buildRequestInit(options);
+    const { signal, didTimeout, cleanup } = buildSignal(options, defaultTimeoutMs);
+    if (signal !== undefined) {
+      init.signal = signal;
+    }
+    const timeoutMs = options.timeoutMs ?? defaultTimeoutMs;
     try {
       const response = await fetchImpl(fullUrl, init);
       const text = await response.text();
       const bodyResult = parseJsonBody(text);
       if (!bodyResult.ok) {
+        if (circuitBreaker !== undefined) {
+          registerFailure(circuitBreaker);
+        }
         return bodyResult;
+      }
+      if (circuitBreaker !== undefined) {
+        registerSuccess(circuitBreaker);
       }
       return ok({
         statusCode: response.status,
@@ -114,7 +216,18 @@ const makeSend =
         path: pathResult.value
       });
     } catch (cause) {
+      if (timeoutMs !== undefined && didTimeout()) {
+        if (circuitBreaker !== undefined) {
+          registerFailure(circuitBreaker);
+        }
+        return err({ kind: 'timeout', timeoutMs });
+      }
+      if (circuitBreaker !== undefined) {
+        registerFailure(circuitBreaker);
+      }
       return err({ kind: 'fetch_failed', cause });
+    } finally {
+      cleanup();
     }
   };
 
@@ -152,7 +265,16 @@ export const createTrembita = (
     fetchImpl = globalThis.fetch,
     log = console
   } = validated.value;
-  const send = makeSend(endpoint, fetchImpl);
+  const { timeoutMs, circuitBreaker } = validated.value;
+  const circuitState =
+    circuitBreaker === undefined
+      ? undefined
+      : {
+          options: circuitBreaker,
+          failures: 0,
+          openedUntilMs: undefined
+        };
+  const send = makeSend(endpoint, fetchImpl, timeoutMs, circuitState);
   const request = makeRequest(endpoint, send);
   return ok({
     endpoint,

--- a/src/trembita.ts
+++ b/src/trembita.ts
@@ -42,6 +42,42 @@ export type TrembitaClient = Readonly<{
   ) => Promise<Result<unknown, TrembitaRequestError>>;
 }>;
 
+const SENSITIVE_HEADER_NAMES = new Set([
+  'authorization',
+  'cookie',
+  'set-cookie',
+  'x-api-key',
+  'proxy-authorization'
+]);
+
+const REDACTED_HEADER_VALUE = '[REDACTED]';
+
+const sanitizeHeaders = (
+  headers: HeadersInit | undefined
+): Readonly<Record<string, string>> => {
+  const sanitized: Record<string, string> = {};
+  const normalizedHeaders = new Headers(headers);
+  normalizedHeaders.forEach((value, key) => {
+    sanitized[key] = SENSITIVE_HEADER_NAMES.has(key)
+      ? REDACTED_HEADER_VALUE
+      : value;
+  });
+  return sanitized;
+};
+
+const callLog = (
+  logger: Logger,
+  level: keyof Logger,
+  event: string,
+  details: Readonly<Record<string, unknown>>
+): void => {
+  const fn = logger[level];
+  if (typeof fn !== 'function') {
+    return;
+  }
+  fn(event, details);
+};
+
 const resolvePath = (
   options: TrembitaFetchOptions
 ): Result<string, TrembitaSendError> => {
@@ -170,6 +206,7 @@ const makeSend =
   (
     endpoint: string,
     fetchImpl: typeof fetch,
+    log: Logger,
     defaultTimeoutMs: number | undefined,
     circuitBreaker: CircuitBreakerState | undefined
   ) =>
@@ -183,20 +220,39 @@ const makeSend =
     if (circuitBreaker !== undefined) {
       const retryAfterMs = isCircuitOpen(circuitBreaker);
       if (retryAfterMs !== undefined) {
+        callLog(log, 'warn', 'request:circuit_open', {
+          endpoint,
+          path: pathResult.value,
+          retryAfterMs
+        });
         return err({ kind: 'circuit_open', retryAfterMs });
       }
     }
+
     let fullUrl = joinEndpointPath(endpoint, pathResult.value);
     const query = resolveQuery(options);
     if (query) {
       fullUrl = appendQuery(fullUrl, query);
     }
+
     const init = buildRequestInit(options);
-    const { signal, didTimeout, cleanup } = buildSignal(options, defaultTimeoutMs);
+    const { signal, didTimeout, cleanup } = buildSignal(
+      options,
+      defaultTimeoutMs
+    );
     if (signal !== undefined) {
       init.signal = signal;
     }
+
     const timeoutMs = options.timeoutMs ?? defaultTimeoutMs;
+    const startedAtMs = Date.now();
+    callLog(log, 'debug', 'request:start', {
+      endpoint,
+      path: pathResult.value,
+      method: init.method ?? 'GET',
+      headers: sanitizeHeaders(init.headers)
+    });
+
     try {
       const response = await fetchImpl(fullUrl, init);
       const text = await response.text();
@@ -205,11 +261,26 @@ const makeSend =
         if (circuitBreaker !== undefined) {
           registerFailure(circuitBreaker);
         }
+        callLog(log, 'error', 'request:invalid_json', {
+          endpoint,
+          path: pathResult.value,
+          statusCode: response.status,
+          durationMs: Date.now() - startedAtMs,
+          errorKind: bodyResult.error.kind
+        });
         return bodyResult;
       }
+
       if (circuitBreaker !== undefined) {
         registerSuccess(circuitBreaker);
       }
+      callLog(log, 'info', 'request:success', {
+        endpoint,
+        path: pathResult.value,
+        statusCode: response.status,
+        durationMs: Date.now() - startedAtMs
+      });
+
       return ok({
         statusCode: response.status,
         body: bodyResult.value,
@@ -220,11 +291,23 @@ const makeSend =
         if (circuitBreaker !== undefined) {
           registerFailure(circuitBreaker);
         }
+        callLog(log, 'error', 'request:timeout', {
+          endpoint,
+          path: pathResult.value,
+          durationMs: Date.now() - startedAtMs,
+          timeoutMs
+        });
         return err({ kind: 'timeout', timeoutMs });
       }
       if (circuitBreaker !== undefined) {
         registerFailure(circuitBreaker);
       }
+      callLog(log, 'error', 'request:fetch_failed', {
+        endpoint,
+        path: pathResult.value,
+        durationMs: Date.now() - startedAtMs,
+        errorKind: 'fetch_failed'
+      });
       return err({ kind: 'fetch_failed', cause });
     } finally {
       cleanup();
@@ -232,7 +315,7 @@ const makeSend =
   };
 
 const makeRequest =
-  (endpoint: string, send: ReturnType<typeof makeSend>) =>
+  (endpoint: string, send: ReturnType<typeof makeSend>, log: Logger) =>
   async (
     options: TrembitaFetchOptions
   ): Promise<Result<unknown, TrembitaRequestError>> => {
@@ -243,6 +326,12 @@ const makeRequest =
     const expectedCodes = options.expectedCodes ?? DEFAULT_EXPECTED_CODES;
     const { statusCode, body, path } = sent.value;
     if (!expectedCodes.includes(statusCode)) {
+      callLog(log, 'warn', 'request:unexpected_status', {
+        endpoint,
+        path,
+        statusCode,
+        expectedCodes
+      });
       return err({
         kind: 'unexpected_status',
         statusCode,
@@ -260,12 +349,15 @@ export const createTrembita = (
   if (!validated.ok) {
     return validated;
   }
+
   const {
     endpoint,
     fetchImpl = globalThis.fetch,
-    log = console
+    log = {},
+    timeoutMs,
+    circuitBreaker
   } = validated.value;
-  const { timeoutMs, circuitBreaker } = validated.value;
+
   const circuitState =
     circuitBreaker === undefined
       ? undefined
@@ -274,8 +366,9 @@ export const createTrembita = (
           failures: 0,
           openedUntilMs: undefined
         };
-  const send = makeSend(endpoint, fetchImpl, timeoutMs, circuitState);
-  const request = makeRequest(endpoint, send);
+
+  const send = makeSend(endpoint, fetchImpl, log, timeoutMs, circuitState);
+  const request = makeRequest(endpoint, send, log);
   return ok({
     endpoint,
     log,

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -12,10 +12,17 @@ export type Logger = Readonly<
   }>
 >;
 
+export type CircuitBreakerOptions = Readonly<{
+  failureThreshold: number;
+  cooldownMs: number;
+}>;
+
 export type TrembitaInitOptions = Readonly<{
   endpoint: string;
   log?: Logger;
   fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+  circuitBreaker?: CircuitBreakerOptions;
 }>;
 
 export const isOptionsObject = (value: unknown): boolean => {
@@ -46,6 +53,31 @@ export const validateInitOptions = (
   if (!endpointResult.ok) {
     return endpointResult;
   }
+
+  const timeoutMs =
+    typeof o.timeoutMs === 'number' &&
+    Number.isFinite(o.timeoutMs) &&
+    o.timeoutMs > 0
+      ? o.timeoutMs
+      : undefined;
+
+  const circuitBreaker =
+    typeof o.circuitBreaker === 'object' && o.circuitBreaker !== null
+      ? (o.circuitBreaker as Record<string, unknown>)
+      : undefined;
+  const failureThreshold =
+    typeof circuitBreaker?.failureThreshold === 'number' &&
+    Number.isFinite(circuitBreaker.failureThreshold) &&
+    circuitBreaker.failureThreshold > 0
+      ? Math.floor(circuitBreaker.failureThreshold)
+      : undefined;
+  const cooldownMs =
+    typeof circuitBreaker?.cooldownMs === 'number' &&
+    Number.isFinite(circuitBreaker.cooldownMs) &&
+    circuitBreaker.cooldownMs > 0
+      ? circuitBreaker.cooldownMs
+      : undefined;
+
   return ok({
     endpoint: endpointResult.value,
     ...(typeof o.log === 'object' && o.log !== null
@@ -53,6 +85,15 @@ export const validateInitOptions = (
       : {}),
     ...(typeof o.fetchImpl === 'function'
       ? { fetchImpl: o.fetchImpl as typeof fetch }
+      : {}),
+    ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+    ...(failureThreshold !== undefined && cooldownMs !== undefined
+      ? {
+          circuitBreaker: {
+            failureThreshold,
+            cooldownMs
+          }
+        }
       : {})
   });
 };

--- a/test/trembita.test.ts
+++ b/test/trembita.test.ts
@@ -461,6 +461,309 @@ describe('createTrembita', () => {
     expect(res.error.kind).toBe('invalid_json');
   });
 
+  it('request returns timeout when timeoutMs is exceeded', async () => {
+    const fetchImpl = vi.fn((_: RequestInfo | URL, init?: RequestInit) => {
+      return new Promise<Response>((_, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          reject(new Error('aborted'));
+        });
+      });
+    });
+    const created = createTrembita({
+      ...clientOptions,
+      fetchImpl
+    });
+    expect(created.ok).toBe(true);
+    if (!created.ok) {
+      return;
+    }
+    const res = await created.value.request({
+      path: '/slow',
+      timeoutMs: 10
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) {
+      return;
+    }
+    expect(res.error).toEqual({
+      kind: 'timeout',
+      timeoutMs: 10
+    });
+  });
+
+  it('request uses init-level timeout when request timeout not provided', async () => {
+    const fetchImpl = vi.fn((_: RequestInfo | URL, init?: RequestInit) => {
+      return new Promise<Response>((_, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          reject(new Error('aborted'));
+        });
+      });
+    });
+    const created = createTrembita({
+      ...clientOptions,
+      timeoutMs: 10,
+      fetchImpl
+    });
+    expect(created.ok).toBe(true);
+    if (!created.ok) {
+      return;
+    }
+    const res = await created.value.request({ path: '/slow' });
+    expect(res.ok).toBe(false);
+    if (res.ok) {
+      return;
+    }
+    expect(res.error).toEqual({
+      kind: 'timeout',
+      timeoutMs: 10
+    });
+  });
+
+  it('opens circuit breaker after consecutive failures', async () => {
+    const fetchImpl = vi.fn(() => Promise.reject(new Error('network')));
+    const created = createTrembita({
+      ...clientOptions,
+      fetchImpl,
+      circuitBreaker: {
+        failureThreshold: 2,
+        cooldownMs: 1_000
+      }
+    });
+    expect(created.ok).toBe(true);
+    if (!created.ok) {
+      return;
+    }
+
+    const first = await created.value.request({ path: '/unstable' });
+    expect(first.ok).toBe(false);
+    if (!first.ok) {
+      expect(first.error.kind).toBe('fetch_failed');
+    }
+
+    const second = await created.value.request({ path: '/unstable' });
+    expect(second.ok).toBe(false);
+    if (!second.ok) {
+      expect(second.error.kind).toBe('fetch_failed');
+    }
+
+    const third = await created.value.request({ path: '/unstable' });
+    expect(third.ok).toBe(false);
+    if (third.ok) {
+      return;
+    }
+    expect(third.error.kind).toBe('circuit_open');
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('counts invalid_json failures in circuit breaker', async () => {
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(new Response('{', { status: 200 }))
+    );
+    const created = createTrembita({
+      ...clientOptions,
+      fetchImpl,
+      circuitBreaker: {
+        failureThreshold: 1,
+        cooldownMs: 1_000
+      }
+    });
+    expect(created.ok).toBe(true);
+    if (!created.ok) {
+      return;
+    }
+
+    const first = await created.value.request({ path: '/broken-json' });
+    expect(first.ok).toBe(false);
+    if (!first.ok) {
+      expect(first.error.kind).toBe('invalid_json');
+    }
+
+    const second = await created.value.request({ path: '/broken-json' });
+    expect(second.ok).toBe(false);
+    if (second.ok) {
+      return;
+    }
+    expect(second.error.kind).toBe('circuit_open');
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('counts timeout failures in circuit breaker', async () => {
+    const fetchImpl = vi.fn((_: RequestInfo | URL, init?: RequestInit) => {
+      return new Promise<Response>((_, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          reject(new Error('aborted'));
+        });
+      });
+    });
+    const created = createTrembita({
+      ...clientOptions,
+      fetchImpl,
+      circuitBreaker: {
+        failureThreshold: 1,
+        cooldownMs: 1_000
+      }
+    });
+    expect(created.ok).toBe(true);
+    if (!created.ok) {
+      return;
+    }
+    const first = await created.value.request({
+      path: '/slow',
+      timeoutMs: 10
+    });
+    expect(first.ok).toBe(false);
+    if (!first.ok) {
+      expect(first.error.kind).toBe('timeout');
+    }
+
+    const second = await created.value.request({
+      path: '/slow',
+      timeoutMs: 10
+    });
+    expect(second.ok).toBe(false);
+    if (second.ok) {
+      return;
+    }
+    expect(second.error.kind).toBe('circuit_open');
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets circuit breaker failure count after success', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('network'))
+      .mockResolvedValueOnce(new Response('{}', { status: 200 }))
+      .mockRejectedValueOnce(new Error('network'))
+      .mockRejectedValueOnce(new Error('network'));
+    const created = createTrembita({
+      ...clientOptions,
+      fetchImpl,
+      circuitBreaker: {
+        failureThreshold: 2,
+        cooldownMs: 1_000
+      }
+    });
+    expect(created.ok).toBe(true);
+    if (!created.ok) {
+      return;
+    }
+
+    const r1 = await created.value.request({ path: '/unstable' });
+    expect(r1.ok).toBe(false);
+    const r2 = await created.value.request({ path: '/unstable' });
+    expect(r2.ok).toBe(true);
+    const r3 = await created.value.request({ path: '/unstable' });
+    expect(r3.ok).toBe(false);
+    if (!r3.ok) {
+      expect(r3.error.kind).toBe('fetch_failed');
+    }
+    const r4 = await created.value.request({ path: '/unstable' });
+    expect(r4.ok).toBe(false);
+    if (!r4.ok) {
+      expect(r4.error.kind).toBe('fetch_failed');
+    }
+  });
+
+  it('accepts external abort signal', async () => {
+    const fetchImpl = vi.fn((_: RequestInfo | URL, init?: RequestInit) => {
+      return new Promise<Response>((_, reject) => {
+        if (init?.signal?.aborted) {
+          reject(new Error('aborted'));
+          return;
+        }
+        init?.signal?.addEventListener('abort', () => {
+          reject(new Error('aborted'));
+        });
+      });
+    });
+    const created = createTrembita({
+      ...clientOptions,
+      fetchImpl
+    });
+    expect(created.ok).toBe(true);
+    if (!created.ok) {
+      return;
+    }
+    const abortController = new AbortController();
+    const reqPromise = created.value.request({
+      path: '/signal',
+      signal: abortController.signal
+    });
+    abortController.abort();
+    const res = await reqPromise;
+    expect(res.ok).toBe(false);
+    if (res.ok) {
+      return;
+    }
+    expect(res.error.kind).toBe('fetch_failed');
+  });
+
+  it('handles already-aborted external signal', async () => {
+    const fetchImpl = vi.fn((_: RequestInfo | URL, init?: RequestInit) => {
+      return new Promise<Response>((_, reject) => {
+        if (init?.signal?.aborted) {
+          reject(new Error('aborted'));
+          return;
+        }
+        reject(new Error('expected aborted signal'));
+      });
+    });
+    const created = createTrembita({
+      ...clientOptions,
+      fetchImpl
+    });
+    expect(created.ok).toBe(true);
+    if (!created.ok) {
+      return;
+    }
+    const abortController = new AbortController();
+    abortController.abort();
+    const res = await created.value.request({
+      path: '/signal-aborted',
+      signal: abortController.signal
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) {
+      return;
+    }
+    expect(res.error.kind).toBe('fetch_failed');
+  });
+
+  it('allows requests again after circuit breaker cooldown', async () => {
+    vi.useFakeTimers();
+    const fetchImpl = vi.fn(() => Promise.reject(new Error('network')));
+    const created = createTrembita({
+      ...clientOptions,
+      fetchImpl,
+      circuitBreaker: {
+        failureThreshold: 1,
+        cooldownMs: 50
+      }
+    });
+    expect(created.ok).toBe(true);
+    if (!created.ok) {
+      vi.useRealTimers();
+      return;
+    }
+    const first = await created.value.request({ path: '/unstable' });
+    expect(first.ok).toBe(false);
+    const second = await created.value.request({ path: '/unstable' });
+    expect(second.ok).toBe(false);
+    if (!second.ok) {
+      expect(second.error.kind).toBe('circuit_open');
+    }
+
+    vi.advanceTimersByTime(51);
+
+    const third = await created.value.request({ path: '/unstable' });
+    expect(third.ok).toBe(false);
+    if (!third.ok) {
+      expect(third.error.kind).toBe('fetch_failed');
+    }
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
   it('parses empty response body as undefined', async () => {
     const fetchImpl = vi.fn(() =>
       Promise.resolve(new Response('', { status: HTTP_OK }))

--- a/test/trembita.test.ts
+++ b/test/trembita.test.ts
@@ -152,13 +152,64 @@ describe('createTrembita', () => {
     });
   });
 
-  it('uses console as default log', () => {
+  it('uses no-op logger as default log', () => {
     const created = createTrembita({ endpoint: 'https://example.com/api' });
     expect(created.ok).toBe(true);
     if (!created.ok) {
       return;
     }
-    expect(created.value.log).toBe(console);
+    expect(created.value.log).toEqual({});
+  });
+
+  it('works without logger methods', async () => {
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(new Response(JSON.stringify(expectedBody), { status: HTTP_OK }))
+    );
+    const created = createTrembita({
+      endpoint: 'https://example.com/api',
+      fetchImpl
+    });
+    expect(created.ok).toBe(true);
+    if (!created.ok) {
+      return;
+    }
+    const res = await created.value.request({ path: '/users' });
+    expect(res.ok).toBe(true);
+  });
+
+  it('redacts sensitive headers in start log event', async () => {
+    const logger = {
+      debug: vi.fn()
+    };
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(new Response(JSON.stringify(expectedBody), { status: HTTP_OK }))
+    );
+    const created = createTrembita({
+      endpoint: 'https://example.com/api',
+      fetchImpl,
+      log: logger
+    });
+    expect(created.ok).toBe(true);
+    if (!created.ok) {
+      return;
+    }
+    const res = await created.value.request({
+      path: '/users',
+      headers: {
+        Authorization: 'Bearer super-secret',
+        'X-Request-Id': 'req-1'
+      }
+    });
+    expect(res.ok).toBe(true);
+    expect(logger.debug).toHaveBeenCalledWith(
+      'request:start',
+      expect.objectContaining({
+        headers: {
+          authorization: '[REDACTED]',
+          'x-request-id': 'req-1'
+        }
+      })
+    );
   });
 
   it('client returns status and body', async () => {


### PR DESCRIPTION
## Summary
- add request-level `timeoutMs` and init-level default timeout support with typed `timeout` errors
- add optional in-memory circuit breaker (`failureThreshold`, `cooldownMs`) that returns typed `circuit_open` when open
- update public types, README docs, and test coverage for timeout + abort signal + circuit recovery paths

## Test plan
- [x] `npm run lint:fix`
- [x] `npm test`
- [x] `npm run build`
- [x] verify coverage stays at 100%

Closes #13.