### PR TITLE
Document dual-package npm OIDC; Prettier CI fixes

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -1,13 +1,20 @@
 name: Release to NPM
 
-# npm Trusted Publishing (OIDC) + first-time token bootstrap:
+# npm Trusted Publishing (OIDC) + optional NPM_TOKEN bootstrap:
 # https://gist.github.com/kettanaito/debde3cabfae4f68d37cf0f8f3a6a666
 #
 # - Node 24+ is required for Trusted Publishing on the npm side.
+# - This repo publishes TWO packages: `trembita` (root) and `@trembita/openapi`.
+#   Each must have its own Trusted Publisher on npmjs.com. If OIDC fails for one
+#   package (e.g. 404 "package not found" during token exchange) while NPM_TOKEN
+#   is set, @semantic-release/npm falls back to token auth for that package; npm
+#   may then return EOTP ("requires a one-time password") for accounts with 2FA.
+#   Fix: add Trusted Publishing for `@trembita/openapi`, or use an npm **Granular**
+#   access token with **Automation** + publish rights and 2FA bypass for CI.
 # - While the NPM_TOKEN secret is set, setup-node uses registry-url + always-auth.
 #   You must pass NODE_AUTH_TOKEN into that same step; otherwise setup-node falls
 #   back to a placeholder token and npm returns E401 / invalid token.
-# - After configuring Trusted Publisher on npmjs.com, remove NPM_TOKEN from repo
+# - After Trusted Publishers exist for BOTH packages, remove NPM_TOKEN from repo
 #   secrets; the conditionals then omit registry-url/always-auth so npm uses OIDC only
 #   (per gist steps 12–14).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,7 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Claude Code (claude.ai/code) when working with
+code in this repository.
 
 ## Commands
 
@@ -17,6 +18,7 @@ npm run build             # tsup ESM + d.ts (root + openapi workspace)
 ```
 
 Run a single test file:
+
 ```bash
 npx vitest run test/trembita.test.ts
 ```
@@ -25,31 +27,41 @@ npx vitest run test/trembita.test.ts
 
 Monorepo with two packages:
 
-- **`src/`** — core library (`trembita`). ESM-only, zero runtime deps, stdlib-first (`fetch`, `URL`). Exports a functional API (`createTrembita`, `Result<T,E>`, retry, tracing, Standard Schema validation).
-- **`packages/openapi/`** — `@trembita/openapi` workspace. OpenAPI-aware client built on the core.
+- **`src/`** — core library (`trembita`). ESM-only, zero runtime deps,
+  stdlib-first (`fetch`, `URL`). Exports a functional API (`createTrembita`,
+  `Result<T,E>`, retry, tracing, Standard Schema validation).
+- **`packages/openapi/`** — `@trembita/openapi` workspace. OpenAPI-aware client
+  built on the core.
 
 ### Core modules (`src/`)
 
-| File | Role |
-|------|------|
-| `trembita.ts` | `createTrembita` factory — main entry point |
-| `result.ts` | `Result<T,E>` / `Ok` / `Err` — no exceptions in public API |
-| `errors.ts` | Type-only error discriminated unions |
-| `validate.ts` | Init-time option validation, `Logger`, `CircuitBreakerOptions` types |
-| `retryingFetch.ts` | `createRetryingFetch` — exponential-backoff wrapper |
-| `standardSchema.ts` | Standard Schema v1 integration |
-| `requestWithStandardSchema.ts` | Combines fetch + schema validation |
-| `tracing.ts` | `traceContextHeaders` — W3C traceparent injection |
-| `url.ts` | URL construction helpers |
+| File                           | Role                                                                 |
+| ------------------------------ | -------------------------------------------------------------------- |
+| `trembita.ts`                  | `createTrembita` factory — main entry point                          |
+| `result.ts`                    | `Result<T,E>` / `Ok` / `Err` — no exceptions in public API           |
+| `errors.ts`                    | Type-only error discriminated unions                                 |
+| `validate.ts`                  | Init-time option validation, `Logger`, `CircuitBreakerOptions` types |
+| `retryingFetch.ts`             | `createRetryingFetch` — exponential-backoff wrapper                  |
+| `standardSchema.ts`            | Standard Schema v1 integration                                       |
+| `requestWithStandardSchema.ts` | Combines fetch + schema validation                                   |
+| `tracing.ts`                   | `traceContextHeaders` — W3C traceparent injection                    |
+| `url.ts`                       | URL construction helpers                                             |
 
 ### Key design rules (from SPEC.md)
 
 - **No class API** — factory functions only.
-- **`Result<T,E>` everywhere** — never throw operational errors; callers narrow with `if (!result.ok)`.
-- **100% coverage required** on `src/` (branches, lines, functions, statements). `src/errors.ts` is excluded (type-only).
+- **`Result<T,E>` everywhere** — never throw operational errors; callers narrow
+  with `if (!result.ok)`.
+- **100% coverage required** on `src/` (branches, lines, functions, statements).
+  `src/errors.ts` is excluded (type-only).
 - **No runtime dependencies** — stdlib fetch/URL only.
 - **ESM-only** (`type: "module"`).
 
 ## Release
 
-Releases are automated via `semantic-release` on push to `main` or `beta`. Conventional commit messages drive version bumps. The workflow uses npm Trusted Publishing (OIDC); while `NPM_TOKEN` secret is present it falls back to token auth.
+Releases are automated via `semantic-release` on push to `main` or `beta`.
+Conventional commit messages drive version bumps. The workflow uses npm Trusted
+Publishing (OIDC) per package; while `NPM_TOKEN` is set, failed OIDC for a
+package (e.g. OpenAPI not linked on npm) falls back to token auth and can hit
+**EOTP** under 2FA—link Trusted Publishers for **both** `trembita` and
+`@trembita/openapi`, or use an Automation granular token.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,10 +21,18 @@ config publishes **two** packages from one run:
 
 **Prerequisites**
 
-- **`NPM_TOKEN`** in repo secrets with permission to publish both the unscoped
-  **`trembita`** package and the scoped **`@trembita/openapi`** package.
+- **Trusted Publishing (recommended):** On npmjs.com, configure **Trusted
+  Publishers** (GitHub Actions OIDC) for **both** **`trembita`** and
+  **`@trembita/openapi`**. If only the root package is linked, the OpenAPI
+  publish step can fall back to **`NPM_TOKEN`** and fail with **EOTP** when your
+  npm account has 2FA (one-time password cannot be entered in CI).
+- **Optional `NPM_TOKEN`:** A repo secret used for bootstrap or when OIDC is
+  unavailable for a package. For CI without interactive 2FA, use an npm
+  **Granular access token** (type **Automation**) with publish rights to both
+  packages, or rely on OIDC only and **omit** `NPM_TOKEN` once both packages
+  have Trusted Publishers (see comments in `.github/workflows/npm-release.yml`).
 - Create the **npm org / scope** `@trembita` if it does not exist, and ensure
-  the token’s user is a member with publish rights.
+  maintainers can publish **`@trembita/openapi`**.
 - **`publishConfig.access: public`** is already set on **`@trembita/openapi`**
   so scoped packages are public on the registry.
 

--- a/README.md
+++ b/README.md
@@ -319,11 +319,11 @@ This version line is a **breaking v2 migration** to the functional `Result` API.
 
 ### @trembita/openapi (new in v2 line)
 
-| Topic       | Action                                                                                                                                                                                                           |
-| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Install     | `npm install trembita @trembita/openapi` — **`trembita` is a peer dependency** (^2) of the OpenAPI package.                                                                                                      |
-| Path typing | Generate `paths` with **`openapi-typescript`**, keep templates aligned with `keyof paths`, expand with **`Result`**.                                                                                             |
-| Publishing  | Same **semantic-release** run publishes **`trembita`** (repo root) then **`@trembita/openapi`** (`packages/openapi`). Ensure **npm** scope **`@trembita`** exists and **`NPM_TOKEN`** can publish both packages. |
+| Topic       | Action                                                                                                                                                                                                                                                                                                                                                    |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Install     | `npm install trembita @trembita/openapi` — **`trembita` is a peer dependency** (^2) of the OpenAPI package.                                                                                                                                                                                                                                               |
+| Path typing | Generate `paths` with **`openapi-typescript`**, keep templates aligned with `keyof paths`, expand with **`Result`**.                                                                                                                                                                                                                                      |
+| Publishing  | Same **semantic-release** run publishes **`trembita`** then **`@trembita/openapi`**. Use **Trusted Publishing** for **both** packages on npm (or an **Automation** granular token); see [CONTRIBUTING.md](CONTRIBUTING.md). If only `trembita` has OIDC and **`NPM_TOKEN`** is set, OpenAPI may fall back to token auth and fail with **EOTP** under 2FA. |
 
 ## Contribute
 

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -119,9 +119,10 @@ npm run spike:openapi
 
 **Published** alongside **`trembita`**: the same **semantic-release** workflow
 runs a second **`@semantic-release/npm`** step with
-**`pkgRoot: packages/openapi`**. Ensure your **npm** account can publish the
-**`@trembita`** scope and that **`NPM_TOKEN`** has access to both packages (see
-[CONTRIBUTING.md](../../CONTRIBUTING.md)).
+**`pkgRoot: packages/openapi`**. Configure **Trusted Publishing** for
+**`@trembita/openapi`** on npm (not only the root **`trembita`** package), or CI
+may fall back to **`NPM_TOKEN`** and return **EOTP** if your npm account uses
+2FA. Details: [CONTRIBUTING.md](../../CONTRIBUTING.md).
 
 **Peer dependency:** consumers should install **`trembita` ^2** next to
 **`@trembita/openapi`** (`peerDependencies` in published manifest; this repo

--- a/test/npm-release-workflow.test.ts
+++ b/test/npm-release-workflow.test.ts
@@ -131,7 +131,9 @@ describe('npm-release.yml workflow', () => {
 
   describe('setup-node: always-auth conditional (NPM Trusted Publishing)', () => {
     it('always-auth is set conditionally based on NPM_TOKEN secret', () => {
-      expect(workflowContent).toContain("always-auth: ${{ secrets.NPM_TOKEN != '' }}");
+      expect(workflowContent).toContain(
+        "always-auth: ${{ secrets.NPM_TOKEN != '' }}"
+      );
     });
 
     it('always-auth and registry-url use the same NPM_TOKEN condition', () => {
@@ -294,7 +296,9 @@ describe('npm-release.yml workflow', () => {
 
     it('test step runs before semantic-release step', () => {
       const testIdx = findLineIndex((l) => /run: npm test/.test(l));
-      const releaseIdx = findLineIndex((l) => l.includes('npx semantic-release'));
+      const releaseIdx = findLineIndex((l) =>
+        l.includes('npx semantic-release')
+      );
       expect(testIdx).toBeGreaterThan(-1);
       expect(releaseIdx).toBeGreaterThan(-1);
       expect(releaseIdx).toBeGreaterThan(testIdx);


### PR DESCRIPTION
Clarifies that Trusted Publishing must be configured for both `trembita` and `@trembita/openapi`, and documents the OIDC 404 → token fallback → EOTP failure chain. Applies Prettier to files that failed Code Quality on main (including `CLAUDE.md` and `test/npm-release-workflow.test.ts`).