### PR TITLE
feat: add OpenAPI contract boundary client

### DIFF
--- a/docs/contract-boundary-client.md
+++ b/docs/contract-boundary-client.md
@@ -1,0 +1,78 @@
+# Contract Boundary Client
+
+## Goal
+
+Make Trembita the safe boundary for backend services that call third-party or
+internal HTTP APIs. The client combines OpenAPI path typing, explicit
+`Result<T, E>` outcomes, optional Standard Schema response validation, and
+per-operation policy in one small API.
+
+## Why this matters
+
+Backend incidents often happen at API boundaries: a downstream service returns a
+wrong status, malformed JSON, an empty body, or a response shape that drifted
+from the TypeScript contract. Static OpenAPI types help at compile time, but
+they do not protect runtime boundaries.
+
+Trembita's differentiator is not another fetch wrapper. It is a contract-first
+anti-corruption layer:
+
+- no thrown operational errors;
+- no truthiness checks on optional `error` fields;
+- tagged `error.kind` for all branches;
+- optional runtime validation for untrusted downstream responses;
+- timeout/header/status policy colocated with the operation.
+
+## MVP API
+
+```ts
+import type { paths } from './generated/paths.js';
+import { createOpenapiClient } from '@trembita/openapi';
+
+const created = createOpenapiClient<paths>({
+  endpoint: 'https://api.example.com',
+  policies: {
+    'GET /users/{userId}': {
+      expectedStatus: 200,
+      timeoutMs: 500,
+      headers: { 'x-service': 'accounts' }
+    }
+  },
+  responseSchemas: {
+    'GET /users/{userId} 200': userSchema
+  }
+});
+
+if (!created.ok) throw new Error('invalid client config');
+
+const user = await created.value.GET('/users/{userId}', {
+  params: { userId: 'alice' }
+});
+
+if (!user.ok) {
+  switch (user.error.kind) {
+    case 'openapi_path_unexpanded':
+    case 'unexpected_status':
+    case 'invalid_response':
+    case 'timeout':
+    case 'fetch_failed':
+      break;
+  }
+}
+```
+
+## Design constraints
+
+- Keep core `trembita` unchanged and dependency-free.
+- Ship the feature from `@trembita/openapi` first.
+- Accept `openapi-typescript` `paths` types; do not require codegen at runtime.
+- Use Standard Schema as the validation adapter; do not bind to Zod/Valibot.
+- Keep policy plain data keyed by `METHOD /path/{param}`.
+- Prefer additive API growth over middleware/plugin systems.
+
+## Follow-up ideas
+
+- Response header typing for generated `responses[status].headers`.
+- Typed error response bodies for non-2xx statuses.
+- Codegen helper that emits policy/schema keys from an OpenAPI document.
+- Optional operation metrics hooks built from the same policy keys.

--- a/docs/contract-boundary-client.md
+++ b/docs/contract-boundary-client.md
@@ -14,6 +14,16 @@ wrong status, malformed JSON, an empty body, or a response shape that drifted
 from the TypeScript contract. Static OpenAPI types help at compile time, but
 they do not protect runtime boundaries.
 
+## Why not compose openapi-fetch + Zod + neverthrow?
+
+You can, but every team then has to design the same boundary contract: how
+transport failures map to validation failures, how unexpected statuses are
+reported, how operation names appear in logs, and how empty/error bodies narrow.
+Trembita provides one operational contract across those cases: every call
+returns `Result`, every failure has stable `error.kind`, and response validation
+is colocated with the OpenAPI operation. The goal is not to replace every
+generated SDK; it is to make backend service boundaries hard to misuse.
+
 Trembita's differentiator is not another fetch wrapper. It is a contract-first
 anti-corruption layer:
 
@@ -27,19 +37,30 @@ anti-corruption layer:
 
 ```ts
 import type { paths } from './generated/paths.js';
-import { createOpenapiClient } from '@trembita/openapi';
+import {
+  createOpenapiClient,
+  openapiOperationKey,
+  openapiResponseSchemaKey
+} from '@trembita/openapi';
+
+const getUser = openapiOperationKey<paths>('GET', '/users/{userId}');
+const getUser200 = openapiResponseSchemaKey<paths>(
+  'GET',
+  '/users/{userId}',
+  200
+);
 
 const created = createOpenapiClient<paths>({
   endpoint: 'https://api.example.com',
   policies: {
-    'GET /users/{userId}': {
+    [getUser]: {
       expectedStatus: 200,
       timeoutMs: 500,
       headers: { 'x-service': 'accounts' }
     }
   },
   responseSchemas: {
-    'GET /users/{userId} 200': userSchema
+    [getUser200]: userSchema
   }
 });
 
@@ -60,6 +81,30 @@ if (!user.ok) {
   }
 }
 ```
+
+## Backend consumer path
+
+Start minimal: create a client with only `endpoint`, call a typed path, and
+branch on `result.ok`. Add `policies` when an operation needs explicit status,
+timeout, or headers. Add `responseSchemas` only for boundaries where runtime
+shape drift would cause a production incident.
+
+Framework examples live in
+[contract-boundary-framework-examples.md](./contract-boundary-framework-examples.md).
+
+## Enterprise/platform notes
+
+The MVP keeps policy as local plain data. That is enough for service-level
+adoption. Larger platform teams can wrap `createOpenapiClient` with shared
+service presets later, without changing the underlying operation policy shape.
+That follow-up should stay additive and avoid global middleware chains.
+
+## Release positioning
+
+Ship and document this as an experimental contract boundary client, not as a
+full generated SDK replacement. The promise is backend boundary safety:
+OpenAPI-guided calls, explicit operational failures, optional runtime
+validation, and policy colocated with the operation.
 
 ## Design constraints
 

--- a/docs/contract-boundary-framework-examples.md
+++ b/docs/contract-boundary-framework-examples.md
@@ -1,0 +1,110 @@
+# Contract Boundary Client Framework Examples
+
+These examples show where the Trembita OpenAPI client belongs in backend apps:
+create one boundary client per downstream service, then translate `Result`
+failures at the framework edge.
+
+## Fastify-style route
+
+```ts
+import type { FastifyInstance } from 'fastify';
+import type { paths } from './generated/users.paths.js';
+import { createOpenapiClient } from '@trembita/openapi';
+
+const usersClient = createOpenapiClient<paths>({
+  endpoint: 'https://users.internal',
+  policies: {
+    'GET /users/{userId}': { expectedStatus: 200, timeoutMs: 500 }
+  },
+  responseSchemas: {
+    'GET /users/{userId} 200': userSchema
+  }
+});
+
+if (!usersClient.ok) throw new Error('invalid users client');
+
+export const registerRoutes = (app: FastifyInstance): void => {
+  app.get('/profiles/:userId', async (request, reply) => {
+    const userId = (request.params as { userId: string }).userId;
+    const user = await usersClient.value.GET('/users/{userId}', {
+      params: { userId }
+    });
+
+    if (!user.ok) {
+      if (user.error.kind === 'unexpected_status')
+        return reply.code(502).send(user.error);
+      if (user.error.kind === 'invalid_response')
+        return reply.code(502).send(user.error);
+      if (user.error.kind === 'timeout')
+        return reply.code(504).send(user.error);
+      return reply.code(500).send(user.error);
+    }
+
+    return reply.send(user.value);
+  });
+};
+```
+
+## Hono / Workers-style route
+
+```ts
+import type { paths } from './generated/users.paths.js';
+import { Hono } from 'hono';
+import { createOpenapiClient } from '@trembita/openapi';
+
+const app = new Hono();
+const usersClient = createOpenapiClient<paths>({
+  endpoint: 'https://users.internal',
+  fetchImpl: fetch,
+  policies: {
+    'GET /users/{userId}': { expectedStatus: 200, timeoutMs: 500 }
+  }
+});
+
+if (!usersClient.ok) throw new Error('invalid users client');
+
+app.get('/profiles/:userId', async (c) => {
+  const user = await usersClient.value.GET('/users/{userId}', {
+    params: { userId: c.req.param('userId') }
+  });
+
+  if (!user.ok) {
+    const status = user.error.kind === 'timeout' ? 504 : 502;
+    return c.json({ error: user.error.kind }, status);
+  }
+
+  return c.json(user.value);
+});
+```
+
+## NestJS-style service
+
+```ts
+import type { paths } from './generated/users.paths.js';
+import { Injectable, BadGatewayException } from '@nestjs/common';
+import { createOpenapiClient } from '@trembita/openapi';
+
+@Injectable()
+export class ProfilesService {
+  private readonly users = createOpenapiClient<paths>({
+    endpoint: 'https://users.internal',
+    policies: {
+      'GET /users/{userId}': { expectedStatus: 200, timeoutMs: 500 }
+    }
+  });
+
+  async getProfile(userId: string) {
+    if (!this.users.ok) throw new Error('invalid users client');
+
+    const user = await this.users.value.GET('/users/{userId}', {
+      params: { userId }
+    });
+
+    if (!user.ok) {
+      throw new BadGatewayException({ downstreamError: user.error.kind });
+    }
+
+    return user.value;
+  }
+}
+```

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -38,15 +38,26 @@ bodies with Standard Schema.
 
 ```typescript
 import type { paths } from './fixtures/mini-api.paths.js';
-import { createOpenapiClient } from '@trembita/openapi';
+import {
+  createOpenapiClient,
+  openapiOperationKey,
+  openapiResponseSchemaKey
+} from '@trembita/openapi';
+
+const getUser = openapiOperationKey<paths>('GET', '/users/{userId}');
+const getUser200 = openapiResponseSchemaKey<paths>(
+  'GET',
+  '/users/{userId}',
+  200
+);
 
 const created = createOpenapiClient<paths>({
   endpoint: 'https://api.example.com',
   policies: {
-    'GET /users/{userId}': { expectedStatus: 200, timeoutMs: 500 }
+    [getUser]: { expectedStatus: 200, timeoutMs: 500 }
   },
   responseSchemas: {
-    'GET /users/{userId} 200': userSchema
+    [getUser200]: userSchema
   }
 });
 
@@ -57,13 +68,28 @@ const user = await created.value.GET('/users/{userId}', {
 });
 
 if (!user.ok) {
-  // ExpandPathError | TrembitaRequestError | { kind: 'invalid_response' }
-  console.error(user.error.kind);
+  // ExpandPathError | TrembitaSendError | unexpected_status | invalid_response
+  console.error(
+    user.error.kind,
+    'operationKey' in user.error ? user.error.operationKey : undefined
+  );
 }
 ```
 
+For small API clients, skip policies and schemas at first:
+
+```typescript
+const created = createOpenapiClient<paths>({
+  endpoint: 'https://api.example.com'
+});
+const user = created.ok
+  ? await created.value.GET('/users/{userId}', { params: { userId: 'alice' } })
+  : created;
+```
+
 See [docs/contract-boundary-client.md](../../docs/contract-boundary-client.md)
-for the design notes.
+for the design notes and
+[framework examples](../../docs/contract-boundary-framework-examples.md).
 
 ## Real `paths` fixture + DX
 

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -22,9 +22,48 @@ no truthiness check on an `error` field that might be empty.
 ## API
 
 - **`expandOpenapiPath(template, params)`** — `Result<string, ExpandPathError>`
+- **`createOpenapiClient<paths>(options)`** — contract boundary client with
+  typed OpenAPI paths, `Result` errors, operation policy, and optional Standard
+  Schema response validation.
 - Re-exports: `createTrembita`, `HTTP_OK`, `createRetryingFetch`,
   `traceContextHeaders`, `validateStandardSchema`, `requestWithStandardSchema`,
   and common types.
+
+## Contract boundary client
+
+`createOpenapiClient<paths>()` turns an `openapi-typescript` `paths` type into a
+small backend boundary client. It expands path params, applies per-operation
+policy, checks the expected status, and optionally validates successful response
+bodies with Standard Schema.
+
+```typescript
+import type { paths } from './fixtures/mini-api.paths.js';
+import { createOpenapiClient } from '@trembita/openapi';
+
+const created = createOpenapiClient<paths>({
+  endpoint: 'https://api.example.com',
+  policies: {
+    'GET /users/{userId}': { expectedStatus: 200, timeoutMs: 500 }
+  },
+  responseSchemas: {
+    'GET /users/{userId} 200': userSchema
+  }
+});
+
+if (!created.ok) throw new Error('invalid client config');
+
+const user = await created.value.GET('/users/{userId}', {
+  params: { userId: 'alice' }
+});
+
+if (!user.ok) {
+  // ExpandPathError | TrembitaRequestError | { kind: 'invalid_response' }
+  console.error(user.error.kind);
+}
+```
+
+See [docs/contract-boundary-client.md](../../docs/contract-boundary-client.md)
+for the design notes.
 
 ## Real `paths` fixture + DX
 

--- a/packages/openapi/src/client.ts
+++ b/packages/openapi/src/client.ts
@@ -1,0 +1,320 @@
+import {
+  createTrembita,
+  err,
+  ok,
+  validateStandardSchema,
+  type CircuitBreakerOptions,
+  type Logger,
+  type Result,
+  type StandardSchemaIssue,
+  type StandardSchemaV1,
+  type TrembitaInitError,
+  type TrembitaRequestError,
+  type TrembitaSendError
+} from 'trembita';
+
+import { expandOpenapiPath, type ExpandPathError } from './expandPath.js';
+
+type OpenapiMethod =
+  | 'get'
+  | 'put'
+  | 'post'
+  | 'delete'
+  | 'options'
+  | 'head'
+  | 'patch'
+  | 'trace';
+
+type PublicMethod = Uppercase<OpenapiMethod>;
+
+type LowerMethod<M extends PublicMethod> = Lowercase<M> & OpenapiMethod;
+
+type PathRecord = object;
+
+type MethodOperation<PathItem, M extends PublicMethod> =
+  LowerMethod<M> extends keyof PathItem
+    ? NonNullable<PathItem[LowerMethod<M>]>
+    : never;
+
+type PathsForMethod<Paths extends PathRecord, M extends PublicMethod> = {
+  [Path in keyof Paths]: MethodOperation<Paths[Path], M> extends never
+    ? never
+    : Path;
+}[keyof Paths] &
+  string;
+
+type Operation<
+  Paths extends PathRecord,
+  M extends PublicMethod,
+  Path extends keyof Paths
+> = MethodOperation<Paths[Path], M>;
+
+type OperationParameters<Op> = Op extends {
+  readonly parameters: infer Parameters;
+}
+  ? Parameters
+  : Record<string, never>;
+
+type PathParams<Op> =
+  OperationParameters<Op> extends {
+    readonly path: infer Params;
+  }
+    ? Params extends never
+      ? Record<string, never>
+      : Params
+    : Record<string, never>;
+
+type QueryParams<Op> =
+  OperationParameters<Op> extends {
+    readonly query?: infer Query;
+  }
+    ? Query extends never
+      ? Record<string, never>
+      : Query
+    : Record<string, never>;
+
+type HeaderParams<Op> =
+  OperationParameters<Op> extends {
+    readonly header?: infer Header;
+  }
+    ? Header extends never
+      ? Record<string, string>
+      : Header
+    : Record<string, string>;
+
+type JsonRequestBody<Op> = Op extends {
+  readonly requestBody: {
+    readonly content: { readonly 'application/json': infer Body };
+  };
+}
+  ? Body
+  : never;
+
+type Responses<Op> = Op extends { readonly responses: infer R } ? R : never;
+
+type StatusKey<Op, Status extends number> = Status extends keyof Responses<Op>
+  ? Status
+  : `${Status}` extends keyof Responses<Op>
+    ? `${Status}`
+    : never;
+
+type JsonResponse<Op, Status extends number> =
+  StatusKey<Op, Status> extends infer Key
+    ? Key extends keyof Responses<Op>
+      ? Responses<Op>[Key] extends {
+          readonly content: { readonly 'application/json': infer Body };
+        }
+        ? Body
+        : unknown
+      : unknown
+    : unknown;
+
+type RequestBodyOption<Op> =
+  JsonRequestBody<Op> extends never
+    ? { readonly body?: never }
+    : { readonly body: JsonRequestBody<Op> };
+
+export type OpenapiOperationPolicy = Readonly<{
+  expectedStatus?: number;
+  timeoutMs?: number;
+  headers?: Readonly<Record<string, string>>;
+}>;
+
+export type OpenapiResponseSchemaMap = Readonly<
+  Record<string, StandardSchemaV1>
+>;
+
+export type OpenapiClientOptions = Readonly<{
+  endpoint: string;
+  fetchImpl?: typeof fetch;
+  log?: Logger;
+  timeoutMs?: number;
+  circuitBreaker?: CircuitBreakerOptions;
+  policies?: Readonly<Record<string, OpenapiOperationPolicy>>;
+  responseSchemas?: OpenapiResponseSchemaMap;
+}>;
+
+export type OpenapiInvalidResponseError = Readonly<{
+  kind: 'invalid_response';
+  method: PublicMethod;
+  path: string;
+  statusCode: number;
+  issues: readonly StandardSchemaIssue[];
+}>;
+
+export type OpenapiClientError =
+  | ExpandPathError
+  | TrembitaSendError
+  | TrembitaRequestError
+  | OpenapiInvalidResponseError;
+
+export type OpenapiRequestOptions<Op> = Readonly<
+  {
+    params: PathParams<Op>;
+    query?: QueryParams<Op>;
+    headers?: HeaderParams<Op> & Readonly<Record<string, string>>;
+    expectedStatus?: number;
+    timeoutMs?: number;
+    signal?: AbortSignal;
+  } & RequestBodyOption<Op>
+>;
+
+type OpenapiCall<Paths extends PathRecord, M extends PublicMethod> = <
+  Path extends PathsForMethod<Paths, M>,
+  Status extends number = 200
+>(
+  path: Path,
+  options: OpenapiRequestOptions<Operation<Paths, M, Path>> &
+    Readonly<{ expectedStatus?: Status }>
+) => Promise<
+  Result<JsonResponse<Operation<Paths, M, Path>, Status>, OpenapiClientError>
+>;
+
+export type OpenapiClient<Paths extends PathRecord> = Readonly<{
+  GET: OpenapiCall<Paths, 'GET'>;
+  PUT: OpenapiCall<Paths, 'PUT'>;
+  POST: OpenapiCall<Paths, 'POST'>;
+  DELETE: OpenapiCall<Paths, 'DELETE'>;
+  PATCH: OpenapiCall<Paths, 'PATCH'>;
+}>;
+
+type RuntimeRequestOptions = Readonly<{
+  params: Readonly<Record<string, unknown>>;
+  query?: Readonly<
+    Record<string, string | number | boolean | null | undefined>
+  >;
+  headers?: Readonly<Record<string, string>>;
+  body?: unknown;
+  expectedStatus?: number;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}>;
+
+const policyKey = (method: PublicMethod, path: string): string =>
+  `${method} ${path}`;
+
+const schemaKey = (
+  method: PublicMethod,
+  path: string,
+  statusCode: number
+): string => `${method} ${path} ${String(statusCode)}`;
+
+const toPathParams = (
+  params: Readonly<Record<string, unknown>>
+): Readonly<Record<string, string | number>> => {
+  const converted: Record<string, string | number> = {};
+  for (const [key, value] of Object.entries(params)) {
+    if (typeof value === 'string' || typeof value === 'number') {
+      converted[key] = value;
+    }
+  }
+  return converted;
+};
+
+const mergeHeaders = (
+  policyHeaders: Readonly<Record<string, string>> | undefined,
+  requestHeaders: Readonly<Record<string, string>> | undefined
+): Readonly<Record<string, string>> | undefined => {
+  if (policyHeaders === undefined && requestHeaders === undefined) {
+    return undefined;
+  }
+  return {
+    ...(policyHeaders ?? {}),
+    ...(requestHeaders ?? {})
+  };
+};
+
+export const createOpenapiClient = <Paths extends PathRecord>(
+  options: OpenapiClientOptions
+): Result<OpenapiClient<Paths>, TrembitaInitError> => {
+  const created = createTrembita(options);
+  if (!created.ok) {
+    return created;
+  }
+
+  const request = async (
+    method: PublicMethod,
+    path: string,
+    requestOptions: RuntimeRequestOptions
+  ): Promise<Result<unknown, OpenapiClientError>> => {
+    const expanded = expandOpenapiPath(
+      path,
+      toPathParams(requestOptions.params)
+    );
+    if (!expanded.ok) {
+      return expanded;
+    }
+
+    const policy = options.policies?.[policyKey(method, path)];
+    const expectedStatus =
+      requestOptions.expectedStatus ?? policy?.expectedStatus ?? 200;
+    const headers = mergeHeaders(policy?.headers, requestOptions.headers);
+    const timeoutMs = requestOptions.timeoutMs ?? policy?.timeoutMs;
+    const sent = await created.value.client({
+      path: expanded.value,
+      method,
+      ...(requestOptions.query === undefined
+        ? {}
+        : { query: requestOptions.query }),
+      ...(headers === undefined ? {} : { headers }),
+      ...('body' in requestOptions ? { body: requestOptions.body } : {}),
+      expectedCodes: [expectedStatus],
+      ...(timeoutMs === undefined ? {} : { timeoutMs }),
+      ...(requestOptions.signal === undefined
+        ? {}
+        : { signal: requestOptions.signal })
+    });
+
+    if (!sent.ok) {
+      return sent;
+    }
+
+    if (sent.value.statusCode !== expectedStatus) {
+      return err({
+        kind: 'unexpected_status',
+        statusCode: sent.value.statusCode,
+        body: sent.value.body,
+        request: {
+          endpoint: created.value.endpoint,
+          path: sent.value.path,
+          expectedCodes: [expectedStatus]
+        }
+      });
+    }
+
+    const schema =
+      options.responseSchemas?.[schemaKey(method, path, sent.value.statusCode)];
+    if (schema === undefined) {
+      return ok(sent.value.body);
+    }
+
+    const validated = await validateStandardSchema(sent.value.body, schema);
+    if (!validated.ok) {
+      return err({
+        kind: 'invalid_response',
+        method,
+        path,
+        statusCode: sent.value.statusCode,
+        issues: validated.error.issues
+      });
+    }
+    return ok(validated.value);
+  };
+
+  const call = <M extends PublicMethod>(method: M): OpenapiCall<Paths, M> => {
+    return ((path: string, requestOptions: unknown) =>
+      request(
+        method,
+        path,
+        requestOptions as RuntimeRequestOptions
+      )) as OpenapiCall<Paths, M>;
+  };
+
+  return ok({
+    GET: call('GET'),
+    PUT: call('PUT'),
+    POST: call('POST'),
+    DELETE: call('DELETE'),
+    PATCH: call('PATCH')
+  });
+};

--- a/packages/openapi/src/client.ts
+++ b/packages/openapi/src/client.ts
@@ -9,7 +9,6 @@ import {
   type StandardSchemaIssue,
   type StandardSchemaV1,
   type TrembitaInitError,
-  type TrembitaRequestError,
   type TrembitaSendError
 } from 'trembita';
 
@@ -66,7 +65,7 @@ type PathParams<Op> =
 
 type QueryParams<Op> =
   OperationParameters<Op> extends {
-    readonly query?: infer Query;
+    readonly query: infer Query;
   }
     ? Query extends never
       ? Record<string, never>
@@ -92,11 +91,21 @@ type JsonRequestBody<Op> = Op extends {
 
 type Responses<Op> = Op extends { readonly responses: infer R } ? R : never;
 
+type StatusFromKey<Key> = Key extends number
+  ? Key
+  : Key extends `${infer Status extends number}`
+    ? Status
+    : never;
+
+type KnownStatus<Op> = StatusFromKey<keyof Responses<Op>>;
+
 type StatusKey<Op, Status extends number> = Status extends keyof Responses<Op>
   ? Status
   : `${Status}` extends keyof Responses<Op>
     ? `${Status}`
-    : never;
+    : 'default' extends keyof Responses<Op>
+      ? 'default'
+      : never;
 
 type JsonResponse<Op, Status extends number> =
   StatusKey<Op, Status> extends infer Key
@@ -105,14 +114,42 @@ type JsonResponse<Op, Status extends number> =
           readonly content: { readonly 'application/json': infer Body };
         }
         ? Body
-        : unknown
+        : undefined
       : unknown
     : unknown;
+
+type EmptyObject<T> = [T] extends [Record<string, never>]
+  ? true
+  : keyof T extends never
+    ? true
+    : false;
+
+type PathParamsOption<Op> =
+  EmptyObject<PathParams<Op>> extends true
+    ? { readonly params?: never }
+    : { readonly params: PathParams<Op> };
+
+type QueryOption<Op> =
+  EmptyObject<QueryParams<Op>> extends true
+    ? { readonly query?: never }
+    : { readonly query: QueryParams<Op> };
 
 type RequestBodyOption<Op> =
   JsonRequestBody<Op> extends never
     ? { readonly body?: never }
     : { readonly body: JsonRequestBody<Op> };
+
+export type OpenapiOperationKey<Paths extends PathRecord> = {
+  [M in PublicMethod]: `${M} ${PathsForMethod<Paths, M>}`;
+}[PublicMethod];
+
+export type OpenapiResponseSchemaKey<Paths extends PathRecord> = {
+  [M in PublicMethod]: {
+    [Path in PathsForMethod<Paths, M>]:
+      | `${M} ${Path} ${KnownStatus<Operation<Paths, M, Path>>}`
+      | `${M} ${Path} default`;
+  }[PathsForMethod<Paths, M>];
+}[PublicMethod];
 
 export type OpenapiOperationPolicy = Readonly<{
   expectedStatus?: number;
@@ -120,43 +157,63 @@ export type OpenapiOperationPolicy = Readonly<{
   headers?: Readonly<Record<string, string>>;
 }>;
 
-export type OpenapiResponseSchemaMap = Readonly<
-  Record<string, StandardSchemaV1>
+export type OpenapiPolicyMap<Paths extends PathRecord> = Readonly<
+  Partial<Record<OpenapiOperationKey<Paths>, OpenapiOperationPolicy>>
 >;
 
-export type OpenapiClientOptions = Readonly<{
+export type OpenapiResponseSchemaMap<Paths extends PathRecord> = Readonly<
+  Partial<Record<OpenapiResponseSchemaKey<Paths>, StandardSchemaV1>>
+>;
+
+export type OpenapiClientOptions<Paths extends PathRecord> = Readonly<{
   endpoint: string;
   fetchImpl?: typeof fetch;
   log?: Logger;
   timeoutMs?: number;
   circuitBreaker?: CircuitBreakerOptions;
-  policies?: Readonly<Record<string, OpenapiOperationPolicy>>;
-  responseSchemas?: OpenapiResponseSchemaMap;
+  policies?: OpenapiPolicyMap<Paths>;
+  responseSchemas?: OpenapiResponseSchemaMap<Paths>;
 }>;
 
 export type OpenapiInvalidResponseError = Readonly<{
   kind: 'invalid_response';
+  operationKey: string;
+  schemaKey: string;
   method: PublicMethod;
+  template: string;
   path: string;
   statusCode: number;
   issues: readonly StandardSchemaIssue[];
 }>;
 
+export type OpenapiUnexpectedStatusError = Readonly<{
+  kind: 'unexpected_status';
+  operationKey: string;
+  method: PublicMethod;
+  template: string;
+  statusCode: number;
+  body: unknown;
+  request: Readonly<{
+    endpoint: string;
+    path: string;
+    expectedCodes: readonly number[];
+  }>;
+}>;
+
 export type OpenapiClientError =
   | ExpandPathError
   | TrembitaSendError
-  | TrembitaRequestError
+  | OpenapiUnexpectedStatusError
   | OpenapiInvalidResponseError;
 
 export type OpenapiRequestOptions<Op> = Readonly<
-  {
-    params: PathParams<Op>;
-    query?: QueryParams<Op>;
-    headers?: HeaderParams<Op> & Readonly<Record<string, string>>;
-    expectedStatus?: number;
-    timeoutMs?: number;
-    signal?: AbortSignal;
-  } & RequestBodyOption<Op>
+  PathParamsOption<Op> &
+    QueryOption<Op> & {
+      headers?: HeaderParams<Op> & Readonly<Record<string, string>>;
+      expectedStatus?: number;
+      timeoutMs?: number;
+      signal?: AbortSignal;
+    } & RequestBodyOption<Op>
 >;
 
 type OpenapiCall<Paths extends PathRecord, M extends PublicMethod> = <
@@ -179,7 +236,7 @@ export type OpenapiClient<Paths extends PathRecord> = Readonly<{
 }>;
 
 type RuntimeRequestOptions = Readonly<{
-  params: Readonly<Record<string, unknown>>;
+  params?: Readonly<Record<string, unknown>>;
   query?: Readonly<
     Record<string, string | number | boolean | null | undefined>
   >;
@@ -190,14 +247,28 @@ type RuntimeRequestOptions = Readonly<{
   signal?: AbortSignal;
 }>;
 
-const policyKey = (method: PublicMethod, path: string): string =>
-  `${method} ${path}`;
+export const openapiOperationKey = <
+  Paths extends PathRecord,
+  M extends PublicMethod = PublicMethod,
+  Path extends PathsForMethod<Paths, M> = PathsForMethod<Paths, M>
+>(
+  method: M,
+  path: Path
+): `${M} ${Path}` => `${method} ${path}`;
 
-const schemaKey = (
-  method: PublicMethod,
-  path: string,
-  statusCode: number
-): string => `${method} ${path} ${String(statusCode)}`;
+export const openapiResponseSchemaKey = <
+  Paths extends PathRecord,
+  M extends PublicMethod = PublicMethod,
+  Path extends PathsForMethod<Paths, M> = PathsForMethod<Paths, M>,
+  Status extends KnownStatus<Operation<Paths, M, Path>> | 'default' =
+    | KnownStatus<Operation<Paths, M, Path>>
+    | 'default'
+>(
+  method: M,
+  path: Path,
+  status: Status
+): `${M} ${Path} ${Status}` =>
+  `${method} ${path} ${String(status)}` as `${M} ${Path} ${Status}`;
 
 const toPathParams = (
   params: Readonly<Record<string, unknown>>
@@ -224,8 +295,27 @@ const mergeHeaders = (
   };
 };
 
+const findResponseSchema = <Paths extends PathRecord>(
+  responseSchemas: OpenapiResponseSchemaMap<Paths> | undefined,
+  method: PublicMethod,
+  path: string,
+  statusCode: number
+): Readonly<{ key: string; schema: StandardSchemaV1 }> | undefined => {
+  const exactKey = `${method} ${path} ${String(statusCode)}`;
+  const exact = responseSchemas?.[exactKey as OpenapiResponseSchemaKey<Paths>];
+  if (exact !== undefined) {
+    return { key: exactKey, schema: exact };
+  }
+  const defaultKey = `${method} ${path} default`;
+  const fallback =
+    responseSchemas?.[defaultKey as OpenapiResponseSchemaKey<Paths>];
+  return fallback === undefined
+    ? undefined
+    : { key: defaultKey, schema: fallback };
+};
+
 export const createOpenapiClient = <Paths extends PathRecord>(
-  options: OpenapiClientOptions
+  options: OpenapiClientOptions<Paths>
 ): Result<OpenapiClient<Paths>, TrembitaInitError> => {
   const created = createTrembita(options);
   if (!created.ok) {
@@ -237,15 +327,17 @@ export const createOpenapiClient = <Paths extends PathRecord>(
     path: string,
     requestOptions: RuntimeRequestOptions
   ): Promise<Result<unknown, OpenapiClientError>> => {
+    const operationKey = `${method} ${path}`;
     const expanded = expandOpenapiPath(
       path,
-      toPathParams(requestOptions.params)
+      toPathParams(requestOptions.params ?? {})
     );
     if (!expanded.ok) {
       return expanded;
     }
 
-    const policy = options.policies?.[policyKey(method, path)];
+    const policy =
+      options.policies?.[operationKey as OpenapiOperationKey<Paths>];
     const expectedStatus =
       requestOptions.expectedStatus ?? policy?.expectedStatus ?? 200;
     const headers = mergeHeaders(policy?.headers, requestOptions.headers);
@@ -272,6 +364,9 @@ export const createOpenapiClient = <Paths extends PathRecord>(
     if (sent.value.statusCode !== expectedStatus) {
       return err({
         kind: 'unexpected_status',
+        operationKey,
+        method,
+        template: path,
         statusCode: sent.value.statusCode,
         body: sent.value.body,
         request: {
@@ -282,18 +377,28 @@ export const createOpenapiClient = <Paths extends PathRecord>(
       });
     }
 
-    const schema =
-      options.responseSchemas?.[schemaKey(method, path, sent.value.statusCode)];
+    const schema = findResponseSchema(
+      options.responseSchemas,
+      method,
+      path,
+      sent.value.statusCode
+    );
     if (schema === undefined) {
       return ok(sent.value.body);
     }
 
-    const validated = await validateStandardSchema(sent.value.body, schema);
+    const validated = await validateStandardSchema(
+      sent.value.body,
+      schema.schema
+    );
     if (!validated.ok) {
       return err({
         kind: 'invalid_response',
+        operationKey,
+        schemaKey: schema.key,
         method,
-        path,
+        template: path,
+        path: sent.value.path,
         statusCode: sent.value.statusCode,
         issues: validated.error.issues
       });

--- a/packages/openapi/src/index.ts
+++ b/packages/openapi/src/index.ts
@@ -4,6 +4,16 @@ export {
   type RequestOpenapiPathError
 } from './requestOpenapiPath.js';
 export {
+  createOpenapiClient,
+  type OpenapiClient,
+  type OpenapiClientError,
+  type OpenapiClientOptions,
+  type OpenapiInvalidResponseError,
+  type OpenapiOperationPolicy,
+  type OpenapiRequestOptions,
+  type OpenapiResponseSchemaMap
+} from './client.js';
+export {
   createTrembita,
   createRetryingFetch,
   HTTP_OK,

--- a/packages/openapi/src/index.ts
+++ b/packages/openapi/src/index.ts
@@ -5,13 +5,19 @@ export {
 } from './requestOpenapiPath.js';
 export {
   createOpenapiClient,
+  openapiOperationKey,
+  openapiResponseSchemaKey,
   type OpenapiClient,
   type OpenapiClientError,
   type OpenapiClientOptions,
   type OpenapiInvalidResponseError,
+  type OpenapiOperationKey,
   type OpenapiOperationPolicy,
+  type OpenapiPolicyMap,
   type OpenapiRequestOptions,
-  type OpenapiResponseSchemaMap
+  type OpenapiResponseSchemaKey,
+  type OpenapiResponseSchemaMap,
+  type OpenapiUnexpectedStatusError
 } from './client.js';
 export {
   createTrembita,

--- a/packages/openapi/test/client.e2e.test.ts
+++ b/packages/openapi/test/client.e2e.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createOpenapiClient, type StandardSchemaV1 } from '../src/index.js';
+import type { paths } from '../fixtures/mini-api.paths.js';
+
+type User = Readonly<{ id: string; name: string }>;
+
+const requestInputToString = (input: RequestInfo | URL): string => {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+};
+
+const userSchema = {
+  '~standard': {
+    version: 1,
+    vendor: 'test',
+    validate: (value: unknown) => {
+      if (
+        typeof value === 'object' &&
+        value !== null &&
+        typeof (value as { readonly id?: unknown }).id === 'string' &&
+        typeof (value as { readonly name?: unknown }).name === 'string'
+      ) {
+        return { value: value as User };
+      }
+      return { issues: [{ message: 'user_invalid' }] };
+    }
+  }
+} satisfies StandardSchemaV1<User>;
+
+describe('createOpenapiClient e2e', () => {
+  it('expands OpenAPI paths, applies policy, validates response, and returns Result data', async () => {
+    const fetchImpl = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      expect(requestInputToString(input)).toBe(
+        'https://api.example.test/users/alice'
+      );
+      expect(init?.method).toBe('GET');
+      expect(new Headers(init?.headers).get('x-service')).toBe('accounts');
+      return Promise.resolve(
+        new Response(JSON.stringify({ id: 'alice', name: 'Alice' }), {
+          status: 200
+        })
+      );
+    });
+
+    const created = createOpenapiClient<paths>({
+      endpoint: 'https://api.example.test',
+      fetchImpl,
+      policies: {
+        'GET /users/{userId}': {
+          expectedStatus: 200,
+          timeoutMs: 500,
+          headers: { 'x-service': 'accounts' }
+        }
+      },
+      responseSchemas: {
+        'GET /users/{userId} 200': userSchema
+      }
+    });
+
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    const result = await created.value.GET('/users/{userId}', {
+      params: { userId: 'alice' }
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.name).toBe('Alice');
+    }
+  });
+
+  it('returns invalid_response when the downstream body violates the schema', async () => {
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(new Response(JSON.stringify({ id: 1 }), { status: 200 }))
+    );
+    const created = createOpenapiClient<paths>({
+      endpoint: 'https://api.example.test',
+      fetchImpl,
+      responseSchemas: {
+        'GET /users/{userId} 200': userSchema
+      }
+    });
+
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    const result = await created.value.GET('/users/{userId}', {
+      params: { userId: 'alice' }
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.kind).toBe('invalid_response');
+      if (result.error.kind === 'invalid_response') {
+        expect(result.error.issues).toContainEqual({ message: 'user_invalid' });
+      }
+    }
+  });
+
+  it('returns unexpected_status before schema validation', async () => {
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ message: 'missing' }), { status: 404 })
+      )
+    );
+    const created = createOpenapiClient<paths>({
+      endpoint: 'https://api.example.test',
+      fetchImpl
+    });
+
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    const result = await created.value.GET('/users/{userId}', {
+      params: { userId: 'alice' }
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.kind).toBe('unexpected_status');
+    }
+  });
+});

--- a/packages/openapi/test/client.e2e.test.ts
+++ b/packages/openapi/test/client.e2e.test.ts
@@ -95,6 +95,9 @@ describe('createOpenapiClient e2e', () => {
     if (!result.ok) {
       expect(result.error.kind).toBe('invalid_response');
       if (result.error.kind === 'invalid_response') {
+        expect(result.error.operationKey).toBe('GET /users/{userId}');
+        expect(result.error.schemaKey).toBe('GET /users/{userId} 200');
+        expect(result.error.path).toBe('/users/alice');
         expect(result.error.issues).toContainEqual({ message: 'user_invalid' });
       }
     }
@@ -121,6 +124,10 @@ describe('createOpenapiClient e2e', () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error.kind).toBe('unexpected_status');
+      if (result.error.kind === 'unexpected_status') {
+        expect(result.error.operationKey).toBe('GET /users/{userId}');
+        expect(result.error.template).toBe('/users/{userId}');
+      }
     }
   });
 });

--- a/packages/openapi/test/client.edge.test.ts
+++ b/packages/openapi/test/client.edge.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createOpenapiClient } from '../src/client.js';
+
+const requestInputToString = (input: RequestInfo | URL): string => {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+};
+
+type edgePaths = {
+  '/search': {
+    get: {
+      parameters: {
+        path?: never;
+        query: { q: string };
+      };
+      requestBody?: never;
+      responses: { 200: { content: { 'application/json': { ok: true } } } };
+    };
+  };
+  '/users/{userId}': {
+    get: {
+      parameters: { path: { userId: string } };
+      requestBody?: never;
+      responses: { 200: { content: { 'application/json': unknown } } };
+    };
+  };
+  '/events': {
+    post: {
+      parameters: { path?: never };
+      requestBody: { content: { 'application/json': { name: string } } };
+      responses: { 201: { content: { 'application/json': { id: string } } } };
+    };
+  };
+};
+
+describe('createOpenapiClient edge cases', () => {
+  it('returns init errors from the core client', () => {
+    const created = createOpenapiClient<edgePaths>({ endpoint: 'ftp://bad' });
+    expect(created.ok).toBe(false);
+    if (!created.ok) {
+      expect(created.error.kind).toBe('endpoint_invalid_url');
+    }
+  });
+
+  it('returns path expansion errors before calling fetch', async () => {
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(new Response('{}', { status: 200 }))
+    );
+    const created = createOpenapiClient<edgePaths>({
+      endpoint: 'https://api.example.test',
+      fetchImpl
+    });
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    const result = await created.value.GET('/users/{userId}', {
+      params: { userId: {} } as never
+    });
+
+    expect(result.ok).toBe(false);
+    expect(fetchImpl).not.toHaveBeenCalled();
+    if (!result.ok) {
+      expect(result.error.kind).toBe('openapi_path_unexpanded');
+    }
+  });
+
+  it('returns send errors from the core client', async () => {
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(new Response('{', { status: 200 }))
+    );
+    const created = createOpenapiClient<edgePaths>({
+      endpoint: 'https://api.example.test',
+      fetchImpl
+    });
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    const result = await created.value.GET('/search', {
+      params: {},
+      query: { q: 'typed' }
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.kind).toBe('invalid_json');
+    }
+  });
+
+  it('returns unvalidated bodies when no response schema is configured', async () => {
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      expect(requestInputToString(input)).toBe(
+        'https://api.example.test/search?q=typed'
+      );
+      return Promise.resolve(
+        new Response(JSON.stringify({ ok: true }), { status: 200 })
+      );
+    });
+    const created = createOpenapiClient<edgePaths>({
+      endpoint: 'https://api.example.test',
+      fetchImpl
+    });
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    const result = await created.value.GET('/search', {
+      params: {},
+      query: { q: 'typed' }
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual({ ok: true });
+    }
+  });
+
+  it('sends JSON bodies and request-level headers', async () => {
+    const fetchImpl = vi.fn((_: RequestInfo | URL, init?: RequestInit) => {
+      expect(init?.method).toBe('POST');
+      expect(init?.body).toBe(JSON.stringify({ name: 'created' }));
+      expect(new Headers(init?.headers).get('x-request')).toBe('yes');
+      return Promise.resolve(
+        new Response(JSON.stringify({ id: 'evt_1' }), { status: 201 })
+      );
+    });
+    const created = createOpenapiClient<edgePaths>({
+      endpoint: 'https://api.example.test',
+      fetchImpl
+    });
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    const result = await created.value.POST('/events', {
+      params: {},
+      headers: { 'x-request': 'yes' },
+      body: { name: 'created' },
+      expectedStatus: 201
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('forwards request-level timeout and abort signal', async () => {
+    const controller = new AbortController();
+    const fetchImpl = vi.fn((_: RequestInfo | URL, init?: RequestInit) => {
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
+      return Promise.resolve(
+        new Response(JSON.stringify({ ok: true }), { status: 200 })
+      );
+    });
+    const created = createOpenapiClient<edgePaths>({
+      endpoint: 'https://api.example.test',
+      fetchImpl
+    });
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    const result = await created.value.GET('/search', {
+      params: {},
+      query: { q: 'typed' },
+      timeoutMs: 100,
+      signal: controller.signal
+    });
+
+    expect(result.ok).toBe(true);
+  });
+});

--- a/packages/openapi/test/client.edge.test.ts
+++ b/packages/openapi/test/client.edge.test.ts
@@ -1,12 +1,24 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { createOpenapiClient } from '../src/client.js';
+import {
+  createOpenapiClient,
+  openapiOperationKey,
+  openapiResponseSchemaKey
+} from '../src/client.js';
 
 const requestInputToString = (input: RequestInfo | URL): string => {
   if (typeof input === 'string') return input;
   if (input instanceof URL) return input.href;
   return input.url;
 };
+
+const okSchema = {
+  '~standard': {
+    version: 1,
+    vendor: 'test',
+    validate: (value: unknown) => ({ value })
+  }
+} as const;
 
 type edgePaths = {
   '/search': {
@@ -33,9 +45,38 @@ type edgePaths = {
       responses: { 201: { content: { 'application/json': { id: string } } } };
     };
   };
+  '/ping': {
+    get: {
+      parameters: { path?: never };
+      requestBody?: never;
+      responses: { 204: { content?: never } };
+    };
+  };
+  '/fallback': {
+    get: {
+      parameters: { path?: never };
+      requestBody?: never;
+      responses: {
+        default: { content: { 'application/json': { ok: boolean } } };
+      };
+    };
+  };
 };
 
 describe('createOpenapiClient edge cases', () => {
+  it('builds typed operation and response schema keys', () => {
+    expect(
+      openapiOperationKey<edgePaths, 'GET', '/search'>('GET', '/search')
+    ).toBe('GET /search');
+    expect(
+      openapiResponseSchemaKey<edgePaths, 'GET', '/search', 200>(
+        'GET',
+        '/search',
+        200
+      )
+    ).toBe('GET /search 200');
+  });
+
   it('returns init errors from the core client', () => {
     const created = createOpenapiClient<edgePaths>({ endpoint: 'ftp://bad' });
     expect(created.ok).toBe(false);
@@ -78,7 +119,6 @@ describe('createOpenapiClient edge cases', () => {
     if (!created.ok) return;
 
     const result = await created.value.GET('/search', {
-      params: {},
       query: { q: 'typed' }
     });
 
@@ -105,8 +145,52 @@ describe('createOpenapiClient edge cases', () => {
     if (!created.ok) return;
 
     const result = await created.value.GET('/search', {
-      params: {},
       query: { q: 'typed' }
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual({ ok: true });
+    }
+  });
+
+  it('supports 204 responses with no JSON content', async () => {
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(new Response(null, { status: 204 }))
+    );
+    const created = createOpenapiClient<edgePaths>({
+      endpoint: 'https://api.example.test',
+      fetchImpl
+    });
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    const result = await created.value.GET('/ping', { expectedStatus: 204 });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBeUndefined();
+    }
+  });
+
+  it('uses default response schema fallback when status-specific schema is absent', async () => {
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ ok: true }), { status: 202 })
+      )
+    );
+    const created = createOpenapiClient<edgePaths>({
+      endpoint: 'https://api.example.test',
+      fetchImpl,
+      responseSchemas: {
+        'GET /fallback default': okSchema
+      }
+    });
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    const result = await created.value.GET('/fallback', {
+      expectedStatus: 202
     });
 
     expect(result.ok).toBe(true);
@@ -132,7 +216,6 @@ describe('createOpenapiClient edge cases', () => {
     if (!created.ok) return;
 
     const result = await created.value.POST('/events', {
-      params: {},
       headers: { 'x-request': 'yes' },
       body: { name: 'created' },
       expectedStatus: 201
@@ -157,7 +240,6 @@ describe('createOpenapiClient edge cases', () => {
     if (!created.ok) return;
 
     const result = await created.value.GET('/search', {
-      params: {},
       query: { q: 'typed' },
       timeoutMs: 100,
       signal: controller.signal


### PR DESCRIPTION
## What

- Add `createOpenapiClient<paths>()` to `@trembita/openapi`.
- Add contract-boundary design notes and README usage.
- Add E2E and edge tests for path expansion, operation policy, response validation, status errors, send errors, query/body/header forwarding, timeout/signal forwarding.

## Links

- Discussion: #354
- Follow-up issues: #355, #356, #357

## Verification

- `npm run typecheck`
- `npm test`
- `npm run lint`
- `npm run build`
- `npm run format`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New typed OpenAPI contract-boundary client: path expansion, per-operation policies (timeout, expected status, headers), optional response schema validation, and structured Result-style error outcomes.

* **Documentation**
  * Added design guide, framework examples, usage docs and README examples describing initialization, calling patterns, and error/validation handling for the client.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->