### PR TITLE
feat: add validation performance telemetry

### DIFF
--- a/docs/contract-boundary-client.md
+++ b/docs/contract-boundary-client.md
@@ -31,6 +31,7 @@ anti-corruption layer:
 - no truthiness checks on optional `error` fields;
 - tagged `error.kind` for all branches;
 - optional runtime validation for untrusted downstream responses;
+- validation timing events for metrics and profiling;
 - timeout/header/status policy colocated with the operation.
 
 ## MVP API
@@ -91,6 +92,8 @@ shape drift would cause a production incident.
 
 Framework examples live in
 [contract-boundary-framework-examples.md](./contract-boundary-framework-examples.md).
+Validation performance guidance lives in
+[contract-boundary-validation-performance.md](./contract-boundary-validation-performance.md).
 
 ## Enterprise/platform notes
 

--- a/docs/contract-boundary-validation-performance.md
+++ b/docs/contract-boundary-validation-performance.md
@@ -1,0 +1,97 @@
+# Contract Boundary Validation Performance
+
+Runtime response validation is opt-in. Add a schema only when a downstream
+response is risky enough to justify runtime work.
+
+## When to validate
+
+Validate responses when:
+
+- the downstream service is outside your deploy boundary;
+- wrong response shape can corrupt data or trigger bad decisions;
+- the endpoint is low-volume or latency-insensitive;
+- the response is small enough to validate cheaply;
+- you need telemetry on contract drift.
+
+Skip validation, or validate only a small envelope, when:
+
+- the endpoint is a hot path;
+- the response contains large arrays or deeply nested objects;
+- the downstream service is owned by the same deployable unit;
+- the response is rendered or forwarded without business decisions;
+- latency budget is tighter than the value of full validation.
+
+## Prefer envelope validation for large collections
+
+For large list endpoints, validate the stable envelope and leave the item array
+to compile-time OpenAPI types unless item-level runtime safety is required.
+
+```ts
+const listUsersEnvelopeSchema = {
+  '~standard': {
+    version: 1,
+    vendor: 'example',
+    validate: (value: unknown) => {
+      if (
+        typeof value === 'object' &&
+        value !== null &&
+        typeof (value as { count?: unknown }).count === 'number' &&
+        Array.isArray((value as { users?: unknown }).users)
+      ) {
+        return { value };
+      }
+      return { issues: [{ message: 'invalid_list_users_envelope' }] };
+    }
+  }
+};
+```
+
+This catches API drift such as missing `count` or a non-array `users` field
+without walking every returned item.
+
+## Measure validation in production-like code
+
+`createOpenapiClient` reports validation timing when a response schema is used:
+
+```ts
+const api = createOpenapiClient<paths>({
+  endpoint: 'https://api.example.com',
+  responseSchemas: {
+    'GET /users 200': listUsersEnvelopeSchema
+  },
+  onValidation: (event) => {
+    metrics.histogram('downstream.validation.duration_ms', event.durationMs, {
+      operation: event.operationKey,
+      schema: event.schemaKey,
+      ok: String(event.ok)
+    });
+  }
+});
+```
+
+The same event is also sent to `log.info('openapi:response_validation', event)`
+when a logger is configured. Logger and hook failures are ignored so telemetry
+cannot break Trembita's `Result` contract.
+
+## Local benchmark
+
+Run:
+
+```bash
+npm run benchmark:validation --workspace=@trembita/openapi
+```
+
+The benchmark compares envelope-only validation with deep item validation for
+100, 1,000, and 10,000 item payloads. Use the output to decide whether an
+operation should validate the entire response or only the envelope.
+
+One local run on this repo showed deep validation scaling with item count while
+envelope validation stayed effectively constant. Treat those numbers as a
+relative signal, not a portable performance guarantee.
+
+## Guidance
+
+- Keep validation opt-in per response status.
+- Validate the smallest shape that protects the business decision.
+- Track validation duration before enabling deep validation on hot endpoints.
+- Treat validation failures as downstream contract incidents, not user errors.

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -23,8 +23,8 @@ no truthiness check on an `error` field that might be empty.
 
 - **`expandOpenapiPath(template, params)`** — `Result<string, ExpandPathError>`
 - **`createOpenapiClient<paths>(options)`** — contract boundary client with
-  typed OpenAPI paths, `Result` errors, operation policy, and optional Standard
-  Schema response validation.
+  typed OpenAPI paths, `Result` errors, operation policy, optional Standard
+  Schema response validation, and validation timing events.
 - Re-exports: `createTrembita`, `HTTP_OK`, `createRetryingFetch`,
   `traceContextHeaders`, `validateStandardSchema`, `requestWithStandardSchema`,
   and common types.
@@ -88,8 +88,9 @@ const user = created.ok
 ```
 
 See [docs/contract-boundary-client.md](../../docs/contract-boundary-client.md)
-for the design notes and
-[framework examples](../../docs/contract-boundary-framework-examples.md).
+for the design notes,
+[framework examples](../../docs/contract-boundary-framework-examples.md), and
+[validation performance guidance](../../docs/contract-boundary-validation-performance.md).
 
 ## Real `paths` fixture + DX
 

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -37,7 +37,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run --coverage",
     "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "lint:fix": "eslint . --fix",
+    "benchmark:validation": "npm run build && node ./scripts/benchmark-validation.mjs"
   },
   "peerDependencies": {
     "trembita": "^2.0.0"

--- a/packages/openapi/scripts/benchmark-validation.mjs
+++ b/packages/openapi/scripts/benchmark-validation.mjs
@@ -1,0 +1,118 @@
+import { performance } from 'node:perf_hooks';
+import { validateStandardSchema } from '../dist/index.js';
+
+const iterations = 200;
+
+const makePayload = (items) => ({
+  ok: true,
+  count: items.length,
+  items
+});
+
+const makeItems = (count) =>
+  Array.from({ length: count }, (_, index) => ({
+    id: `item_${index}`,
+    name: `Item ${index}`,
+    active: index % 2 === 0
+  }));
+
+const envelopeSchema = {
+  '~standard': {
+    version: 1,
+    vendor: 'benchmark',
+    validate: (value) => {
+      if (
+        typeof value === 'object' &&
+        value !== null &&
+        value.ok === true &&
+        typeof value.count === 'number' &&
+        Array.isArray(value.items)
+      ) {
+        return { value };
+      }
+      return { issues: [{ message: 'invalid_envelope' }] };
+    }
+  }
+};
+
+const deepSchema = {
+  '~standard': {
+    version: 1,
+    vendor: 'benchmark',
+    validate: (value) => {
+      if (
+        typeof value !== 'object' ||
+        value === null ||
+        value.ok !== true ||
+        typeof value.count !== 'number' ||
+        !Array.isArray(value.items)
+      ) {
+        return { issues: [{ message: 'invalid_envelope' }] };
+      }
+      for (const item of value.items) {
+        if (
+          typeof item !== 'object' ||
+          item === null ||
+          typeof item.id !== 'string' ||
+          typeof item.name !== 'string' ||
+          typeof item.active !== 'boolean'
+        ) {
+          return { issues: [{ message: 'invalid_item' }] };
+        }
+      }
+      return { value };
+    }
+  }
+};
+
+const runCase = async (name, schema, payload) => {
+  await validateStandardSchema(payload, schema);
+  const started = performance.now();
+  for (let i = 0; i < iterations; i += 1) {
+    const result = await validateStandardSchema(payload, schema);
+    if (!result.ok) {
+      throw new Error(`benchmark case failed: ${name}`);
+    }
+  }
+  const totalMs = performance.now() - started;
+  return {
+    name,
+    iterations,
+    totalMs,
+    avgMs: totalMs / iterations
+  };
+};
+
+const formatMs = (value) => `${value.toFixed(4)}ms`;
+
+const main = async () => {
+  const cases = [
+    ['envelope only / 100 items', envelopeSchema, makePayload(makeItems(100))],
+    ['deep items / 100 items', deepSchema, makePayload(makeItems(100))],
+    [
+      'envelope only / 1000 items',
+      envelopeSchema,
+      makePayload(makeItems(1000))
+    ],
+    ['deep items / 1000 items', deepSchema, makePayload(makeItems(1000))],
+    [
+      'envelope only / 10000 items',
+      envelopeSchema,
+      makePayload(makeItems(10000))
+    ],
+    ['deep items / 10000 items', deepSchema, makePayload(makeItems(10000))]
+  ];
+
+  console.log(
+    `Standard Schema validation benchmark (${iterations} iterations)`
+  );
+  console.log('case,total,avg');
+  for (const [name, schema, payload] of cases) {
+    const result = await runCase(name, schema, payload);
+    console.log(
+      `${result.name},${formatMs(result.totalMs)},${formatMs(result.avgMs)}`
+    );
+  }
+};
+
+await main();

--- a/packages/openapi/src/client.ts
+++ b/packages/openapi/src/client.ts
@@ -165,6 +165,18 @@ export type OpenapiResponseSchemaMap<Paths extends PathRecord> = Readonly<
   Partial<Record<OpenapiResponseSchemaKey<Paths>, StandardSchemaV1>>
 >;
 
+export type OpenapiValidationEvent = Readonly<{
+  operationKey: string;
+  schemaKey: string;
+  method: PublicMethod;
+  template: string;
+  path: string;
+  statusCode: number;
+  durationMs: number;
+  ok: boolean;
+  issueCount: number;
+}>;
+
 export type OpenapiClientOptions<Paths extends PathRecord> = Readonly<{
   endpoint: string;
   fetchImpl?: typeof fetch;
@@ -173,6 +185,7 @@ export type OpenapiClientOptions<Paths extends PathRecord> = Readonly<{
   circuitBreaker?: CircuitBreakerOptions;
   policies?: OpenapiPolicyMap<Paths>;
   responseSchemas?: OpenapiResponseSchemaMap<Paths>;
+  onValidation?: (event: OpenapiValidationEvent) => void;
 }>;
 
 export type OpenapiInvalidResponseError = Readonly<{
@@ -295,6 +308,25 @@ const mergeHeaders = (
   };
 };
 
+const nowMs = (): number => performance.now();
+
+const reportValidation = (
+  logger: Logger | undefined,
+  onValidation: ((event: OpenapiValidationEvent) => void) | undefined,
+  event: OpenapiValidationEvent
+): void => {
+  try {
+    logger?.info?.('openapi:response_validation', event);
+  } catch {
+    /* user logger must not break Result/no-throw contract */
+  }
+  try {
+    onValidation?.(event);
+  } catch {
+    /* user hook must not break Result/no-throw contract */
+  }
+};
+
 const findResponseSchema = <Paths extends PathRecord>(
   responseSchemas: OpenapiResponseSchemaMap<Paths> | undefined,
   method: PublicMethod,
@@ -387,11 +419,24 @@ export const createOpenapiClient = <Paths extends PathRecord>(
       return ok(sent.value.body);
     }
 
+    const validationStartedMs = nowMs();
     const validated = await validateStandardSchema(
       sent.value.body,
       schema.schema
     );
+    const durationMs = nowMs() - validationStartedMs;
     if (!validated.ok) {
+      reportValidation(options.log, options.onValidation, {
+        operationKey,
+        schemaKey: schema.key,
+        method,
+        template: path,
+        path: sent.value.path,
+        statusCode: sent.value.statusCode,
+        durationMs,
+        ok: false,
+        issueCount: validated.error.issues.length
+      });
       return err({
         kind: 'invalid_response',
         operationKey,
@@ -403,6 +448,17 @@ export const createOpenapiClient = <Paths extends PathRecord>(
         issues: validated.error.issues
       });
     }
+    reportValidation(options.log, options.onValidation, {
+      operationKey,
+      schemaKey: schema.key,
+      method,
+      template: path,
+      path: sent.value.path,
+      statusCode: sent.value.statusCode,
+      durationMs,
+      ok: true,
+      issueCount: 0
+    });
     return ok(validated.value);
   };
 

--- a/packages/openapi/src/index.ts
+++ b/packages/openapi/src/index.ts
@@ -17,7 +17,8 @@ export {
   type OpenapiRequestOptions,
   type OpenapiResponseSchemaKey,
   type OpenapiResponseSchemaMap,
-  type OpenapiUnexpectedStatusError
+  type OpenapiUnexpectedStatusError,
+  type OpenapiValidationEvent
 } from './client.js';
 export {
   createTrembita,

--- a/packages/openapi/test/client.e2e.test.ts
+++ b/packages/openapi/test/client.e2e.test.ts
@@ -44,9 +44,13 @@ describe('createOpenapiClient e2e', () => {
       );
     });
 
+    const onValidation = vi.fn();
+    const log = { info: vi.fn() };
     const created = createOpenapiClient<paths>({
       endpoint: 'https://api.example.test',
       fetchImpl,
+      log,
+      onValidation,
       policies: {
         'GET /users/{userId}': {
           expectedStatus: 200,
@@ -70,15 +74,30 @@ describe('createOpenapiClient e2e', () => {
     if (result.ok) {
       expect(result.value.name).toBe('Alice');
     }
+    expect(onValidation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operationKey: 'GET /users/{userId}',
+        schemaKey: 'GET /users/{userId} 200',
+        path: '/users/alice',
+        ok: true,
+        issueCount: 0
+      })
+    );
+    expect(log.info).toHaveBeenCalledWith(
+      'openapi:response_validation',
+      expect.objectContaining({ ok: true })
+    );
   });
 
   it('returns invalid_response when the downstream body violates the schema', async () => {
     const fetchImpl = vi.fn(() =>
       Promise.resolve(new Response(JSON.stringify({ id: 1 }), { status: 200 }))
     );
+    const onValidation = vi.fn();
     const created = createOpenapiClient<paths>({
       endpoint: 'https://api.example.test',
       fetchImpl,
+      onValidation,
       responseSchemas: {
         'GET /users/{userId} 200': userSchema
       }
@@ -101,6 +120,9 @@ describe('createOpenapiClient e2e', () => {
         expect(result.error.issues).toContainEqual({ message: 'user_invalid' });
       }
     }
+    expect(onValidation).toHaveBeenCalledWith(
+      expect.objectContaining({ ok: false, issueCount: 1 })
+    );
   });
 
   it('returns unexpected_status before schema validation', async () => {

--- a/packages/openapi/test/client.edge.test.ts
+++ b/packages/openapi/test/client.edge.test.ts
@@ -128,6 +128,37 @@ describe('createOpenapiClient edge cases', () => {
     }
   });
 
+  it('ignores validation telemetry failures to preserve Result contract', async () => {
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ ok: true }), { status: 200 })
+      )
+    );
+    const created = createOpenapiClient<edgePaths>({
+      endpoint: 'https://api.example.test',
+      fetchImpl,
+      log: {
+        info: () => {
+          throw new Error('logger failed');
+        }
+      },
+      onValidation: () => {
+        throw new Error('hook failed');
+      },
+      responseSchemas: {
+        'GET /search 200': okSchema
+      }
+    });
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    const result = await created.value.GET('/search', {
+      query: { q: 'typed' }
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
   it('returns unvalidated bodies when no response schema is configured', async () => {
     const fetchImpl = vi.fn((input: RequestInfo | URL) => {
       expect(requestInputToString(input)).toBe(

--- a/packages/openapi/test/client.edge.test.ts
+++ b/packages/openapi/test/client.edge.test.ts
@@ -159,8 +159,13 @@ describe('createOpenapiClient edge cases', () => {
     });
 
     expect(result.ok).toBe(true);
-    expect(logInfo).toHaveBeenCalledTimes(1);
-    expect(onValidation).toHaveBeenCalledTimes(1);
+    expect(logInfo).toHaveBeenCalledWith(
+      'openapi:response_validation',
+      expect.objectContaining({ ok: true })
+    );
+    expect(onValidation).toHaveBeenCalledWith(
+      expect.objectContaining({ ok: true })
+    );
   });
 
   it('returns unvalidated bodies when no response schema is configured', async () => {

--- a/packages/openapi/test/client.edge.test.ts
+++ b/packages/openapi/test/client.edge.test.ts
@@ -134,17 +134,19 @@ describe('createOpenapiClient edge cases', () => {
         new Response(JSON.stringify({ ok: true }), { status: 200 })
       )
     );
+    const logInfo = vi.fn(() => {
+      throw new Error('logger failed');
+    });
+    const onValidation = vi.fn(() => {
+      throw new Error('hook failed');
+    });
     const created = createOpenapiClient<edgePaths>({
       endpoint: 'https://api.example.test',
       fetchImpl,
       log: {
-        info: () => {
-          throw new Error('logger failed');
-        }
+        info: logInfo
       },
-      onValidation: () => {
-        throw new Error('hook failed');
-      },
+      onValidation,
       responseSchemas: {
         'GET /search 200': okSchema
       }
@@ -157,6 +159,8 @@ describe('createOpenapiClient edge cases', () => {
     });
 
     expect(result.ok).toBe(true);
+    expect(logInfo).toHaveBeenCalledTimes(1);
+    expect(onValidation).toHaveBeenCalledTimes(1);
   });
 
   it('returns unvalidated bodies when no response schema is configured', async () => {


### PR DESCRIPTION
## What

Closes #359.

- Add validation telemetry for `createOpenapiClient`: `onValidation(event)` and `log.info('openapi:response_validation', event)`.
- Add validation performance guidance with when-to-validate, when-to-skip, envelope validation, and production metrics examples.
- Add `npm run benchmark:validation --workspace=@trembita/openapi` for envelope vs deep payload validation.
- Add tests for validation timing events, failed validation events, and telemetry hook/logger failure isolation.

## Verification

- `npm run typecheck`
- `npm test`
- `npm run lint`
- `npm run build`
- `npm run format`
- `npm run benchmark:validation --workspace=@trembita/openapi`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional validation event callback to track response schema validation timing and outcomes in production-like environments

* **Documentation**
  * Added comprehensive validation performance guidance with decision criteria for enabling runtime validation at contract boundaries
  * Provided envelope-only validation optimization strategies, practical examples, and local benchmark tool for comparing validation performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->